### PR TITLE
Fix bug: dragging area control vertices in mapbox

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-database-ktx'
 
     // Import Mapbox
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.1'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v9:0.7.0'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,9 +66,9 @@ dependencies {
     implementation 'com.google.firebase:firebase-database-ktx'
 
     // Import Mapbox
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.1'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.0'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v9:0.7.0'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
 
     // Import mavsdk to control the drone
     implementation 'io.mavsdk:mavsdk:0.8.0'

--- a/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxAreaBuilderDrawer.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxAreaBuilderDrawer.kt
@@ -9,6 +9,7 @@
 package ch.epfl.sdp.drone3d.map
 
 import android.graphics.Color
+import android.util.Log
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.maps.MapboxMap
@@ -28,7 +29,7 @@ class MapboxAreaBuilderDrawer(
 
     companion object {
         private const val REGION_FILL_OPACITY: Float = 0.5F
-        private const val WAYPOINT_RADIUS: Float = 8f
+        private const val WAYPOINT_RADIUS: Float = 20f
     }
 
     val onVertexMoved = mutableListOf<(old: LatLng, new: LatLng) -> Unit>()
@@ -45,16 +46,23 @@ class MapboxAreaBuilderDrawer(
     private val dragListener = object : OnCircleDragListener {
         lateinit var previousLocation: LatLng
         override fun onAnnotationDragStarted(annotation: Circle) {
+            Log.e("debug-drag", "Start drag")
+
             previousLocation = annotation.latLng
             onLongClickConsumed()
         }
 
         override fun onAnnotationDrag(annotation: Circle) {
+            Log.e("debug-drag", "Dragging")
+
             onVertexMoved.forEach { it(previousLocation, annotation.latLng) }
             previousLocation = annotation.latLng
+
         }
 
         override fun onAnnotationDragFinished(annotation: Circle?) {
+            Log.e("debug-drag", "Stop dragging")
+
         }
     }
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxAreaBuilderDrawer.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxAreaBuilderDrawer.kt
@@ -23,7 +23,6 @@ class MapboxAreaBuilderDrawer(
     mapView: MapView,
     mapboxMap: MapboxMap,
     style: Style,
-    onLongClickConsumed: () -> Boolean
 ) : MapboxDrawer {
 
     companion object {
@@ -38,21 +37,17 @@ class MapboxAreaBuilderDrawer(
 
     private lateinit var fillArea: Fill
 
-    private var reset: Boolean = false
-
     private var nbVertices = 0
 
     private val dragListener = object : OnCircleDragListener {
         lateinit var previousLocation: LatLng
         override fun onAnnotationDragStarted(annotation: Circle) {
             previousLocation = annotation.latLng
-            onLongClickConsumed()
         }
 
         override fun onAnnotationDrag(annotation: Circle) {
             onVertexMoved.forEach { it(previousLocation, annotation.latLng) }
             previousLocation = annotation.latLng
-
         }
 
         override fun onAnnotationDragFinished(annotation: Circle?) {
@@ -61,11 +56,6 @@ class MapboxAreaBuilderDrawer(
 
     init {
         circleManager.addDragListener(dragListener)
-        //circleManager.addLongClickListener { onLongClickConsumed() }
-    }
-
-    fun getUpperLayer(): String {
-        return circleManager.layerId
     }
 
     override fun onDestroy() {
@@ -84,13 +74,11 @@ class MapboxAreaBuilderDrawer(
         val controlVertices = drawableArea.getControlVertices()
         val shapeVertices = drawableArea.getShapeVertices()
 
-        if (controlVertices.size != nbVertices || reset) {
+        if (controlVertices.size != nbVertices) {
             drawControlVertices(controlVertices)
             nbVertices = controlVertices.size
         }
         drawShape(shapeVertices ?: listOf())
-
-        reset = false
     }
 
     /**
@@ -100,8 +88,7 @@ class MapboxAreaBuilderDrawer(
      */
     private fun drawShape(shapeOutline: List<LatLng>) {
 
-        if (!::fillArea.isInitialized || reset) {
-
+        if (!::fillArea.isInitialized) {
             fillManager.deleteAll()
             val fillOption = FillOptions()
                 .withLatLngs(listOf(shapeOutline))

--- a/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxAreaBuilderDrawer.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxAreaBuilderDrawer.kt
@@ -9,7 +9,6 @@
 package ch.epfl.sdp.drone3d.map
 
 import android.graphics.Color
-import android.util.Log
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.maps.MapboxMap
@@ -46,29 +45,23 @@ class MapboxAreaBuilderDrawer(
     private val dragListener = object : OnCircleDragListener {
         lateinit var previousLocation: LatLng
         override fun onAnnotationDragStarted(annotation: Circle) {
-            Log.e("debug-drag", "Start drag")
-
             previousLocation = annotation.latLng
             onLongClickConsumed()
         }
 
         override fun onAnnotationDrag(annotation: Circle) {
-            Log.e("debug-drag", "Dragging")
-
             onVertexMoved.forEach { it(previousLocation, annotation.latLng) }
             previousLocation = annotation.latLng
 
         }
 
         override fun onAnnotationDragFinished(annotation: Circle?) {
-            Log.e("debug-drag", "Stop dragging")
-
         }
     }
 
     init {
         circleManager.addDragListener(dragListener)
-        circleManager.addLongClickListener { onLongClickConsumed() }
+        //circleManager.addLongClickListener { onLongClickConsumed() }
     }
 
     fun getUpperLayer(): String {

--- a/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxAreaBuilderDrawer.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxAreaBuilderDrawer.kt
@@ -28,7 +28,7 @@ class MapboxAreaBuilderDrawer(
 
     companion object {
         private const val REGION_FILL_OPACITY: Float = 0.5F
-        private const val WAYPOINT_RADIUS: Float = 20f
+        private const val WAYPOINT_RADIUS: Float = 8f
     }
 
     val onVertexMoved = mutableListOf<(old: LatLng, new: LatLng) -> Unit>()

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
@@ -65,10 +65,9 @@ class ItineraryCreateActivity : BaseMapActivity(), OnMapReadyCallback,
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        super.initMapView(savedInstanceState,R.layout.activity_itinerary_create, R.id.mapView)
-
         Mapbox.getInstance(this, getString(R.string.mapbox_access_token))
-
+        super.initMapView(savedInstanceState,R.layout.activity_itinerary_create, R.id.mapView)
+        
         mapView.getMapAsync(this)
         mapView.contentDescription = getString(R.string.map_not_ready)
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
@@ -23,6 +23,7 @@ import ch.epfl.sdp.drone3d.map.area.AreaBuilder
 import ch.epfl.sdp.drone3d.map.area.PolygonBuilder
 import ch.epfl.sdp.drone3d.map.gps.LocationComponentManager
 import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
+import ch.epfl.sdp.drone3d.ui.map.BaseMapActivity
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.mapbox.mapboxsdk.Mapbox
 import com.mapbox.mapboxsdk.geometry.LatLng
@@ -37,13 +38,12 @@ import javax.inject.Inject
  * The activity that allows the user to create itinerary using a map.
  */
 @AndroidEntryPoint
-class ItineraryCreateActivity : AppCompatActivity(), OnMapReadyCallback,
-    MapboxMap.OnMapClickListener, MapboxMap.OnMapLongClickListener {
+class ItineraryCreateActivity : BaseMapActivity(), OnMapReadyCallback,
+    MapboxMap.OnMapClickListener {
     @Inject
     lateinit var authService: AuthenticationService
 
     // Map
-    private lateinit var mapView: MapView
     private var isMapReady = false
     private lateinit var mapboxMap: MapboxMap
 
@@ -58,20 +58,16 @@ class ItineraryCreateActivity : AppCompatActivity(), OnMapReadyCallback,
 
     // Drawer
     private lateinit var missionDrawer: MapboxMissionDrawer
+    private lateinit var areaBuilderDrawer: MapboxAreaBuilderDrawer
 
     // Area
-    private var longClickConsumed = false
     private lateinit var areaBuilder: AreaBuilder
-    private lateinit var areaBuilderDrawer: MapboxAreaBuilderDrawer
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        super.initMapView(savedInstanceState,R.layout.activity_itinerary_create, R.id.mapView)
 
         Mapbox.getInstance(this, getString(R.string.mapbox_access_token))
-        setContentView(R.layout.activity_itinerary_create)
-
-        mapView = findViewById(R.id.mapView)
-        mapView.onCreate(savedInstanceState)
 
         mapView.getMapAsync(this)
         mapView.contentDescription = getString(R.string.map_not_ready)
@@ -102,61 +98,27 @@ class ItineraryCreateActivity : AppCompatActivity(), OnMapReadyCallback,
         mapboxMap.setStyle(Style.MAPBOX_STREETS) { style ->
             locationComponentManager.enableLocationComponent(style)
 
-            fun onLongClickConsumed(): Boolean {
-                longClickConsumed = true;
-                return false
-            }
+            areaBuilder = PolygonBuilder()
+            //areaBuilder = ParallelogramBuilder()
+            areaBuilder.onVerticesChanged.add { areaBuilderDrawer.draw(areaBuilder) }
+            //areaBuilder.onAreaChanged.add { missionBuilder.withSearchArea(it) }
 
 
             missionDrawer = MapboxMissionDrawer(mapView, mapboxMap, style)
-
+            // Need to be the last Drawer instanciated to allow draggable vertex
+            areaBuilderDrawer =
+                MapboxAreaBuilderDrawer(mapView, mapboxMap, style)
+            areaBuilderDrawer.onVertexMoved.add { old, new -> areaBuilder.moveVertex(old, new) }
 
 
             mapboxMap.addOnMapClickListener(this)
-            mapboxMap.addOnMapLongClickListener(this)
-
-            areaBuilder = PolygonBuilder()
-            //areaBuilder = ParallelogramBuilder()
-
-            // Need to be the last Drawer instanciated to allow draggable vertex
-            areaBuilderDrawer =
-                MapboxAreaBuilderDrawer(mapView, mapboxMap, style) { onLongClickConsumed() }
-
-            //areaBuilder.onAreaChanged.add { missionBuilder.withSearchArea(it) }
-            areaBuilder.onVerticesChanged.add { areaBuilderDrawer.draw(areaBuilder) }
-            areaBuilderDrawer.onVertexMoved.add { old, new -> areaBuilder.moveVertex(old, new) }
-
         }
+
         // Used to detect when the map is ready in tests
         mapView.contentDescription = getString(R.string.map_ready)
 
         this.mapboxMap = mapboxMap
         isMapReady = true
-    }
-
-    override fun onStart() {
-        super.onStart()
-        mapView.onStart()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        mapView.onResume()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        mapView.onPause()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        mapView.onStop()
-    }
-
-    override fun onLowMemory() {
-        super.onLowMemory()
-        mapView.onLowMemory()
     }
 
     override fun onDestroy() {
@@ -188,10 +150,4 @@ class ItineraryCreateActivity : AppCompatActivity(), OnMapReadyCallback,
         }
         return true
     }
-
-    override fun onMapLongClick(point: LatLng): Boolean {
-        longClickConsumed = false
-        return true
-    }
-
 }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
@@ -17,11 +17,11 @@ import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import ch.epfl.sdp.drone3d.R
-import ch.epfl.sdp.drone3d.map.gps.LocationComponentManager
 import ch.epfl.sdp.drone3d.map.MapboxAreaBuilderDrawer
 import ch.epfl.sdp.drone3d.map.MapboxMissionDrawer
 import ch.epfl.sdp.drone3d.map.area.AreaBuilder
 import ch.epfl.sdp.drone3d.map.area.PolygonBuilder
+import ch.epfl.sdp.drone3d.map.gps.LocationComponentManager
 import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.mapbox.mapboxsdk.Mapbox
@@ -56,14 +56,13 @@ class ItineraryCreateActivity : AppCompatActivity(), OnMapReadyCallback,
     // Location
     lateinit var locationComponentManager: LocationComponentManager
 
+    // Drawer
+    private lateinit var missionDrawer: MapboxMissionDrawer
+
     // Area
     private var longClickConsumed = false
     private lateinit var areaBuilder: AreaBuilder
     private lateinit var areaBuilderDrawer: MapboxAreaBuilderDrawer
-
-    // Drawer
-    private lateinit var missionDrawer: MapboxMissionDrawer
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -88,7 +87,7 @@ class ItineraryCreateActivity : AppCompatActivity(), OnMapReadyCallback,
     fun goToSaveActivity(@Suppress("UNUSED_PARAMETER") view: View) {
 
         // TODO Replace by the actual MappingMission flight path once we are able to generate it from an area
-        if (areaBuilder.getShapeVertices() != null){
+        if (areaBuilder.getShapeVertices() != null) {
             flightPath = ArrayList(areaBuilder.getShapeVertices());
         }
 
@@ -108,15 +107,20 @@ class ItineraryCreateActivity : AppCompatActivity(), OnMapReadyCallback,
                 return false
             }
 
-            areaBuilderDrawer =
-                MapboxAreaBuilderDrawer(mapView, mapboxMap, style) { onLongClickConsumed() }
+
             missionDrawer = MapboxMissionDrawer(mapView, mapboxMap, style)
+
+
 
             mapboxMap.addOnMapClickListener(this)
             mapboxMap.addOnMapLongClickListener(this)
 
             areaBuilder = PolygonBuilder()
             //areaBuilder = ParallelogramBuilder()
+
+            // Need to be the last Drawer instanciated to allow draggable vertex
+            areaBuilderDrawer =
+                MapboxAreaBuilderDrawer(mapView, mapboxMap, style) { onLongClickConsumed() }
 
             //areaBuilder.onAreaChanged.add { missionBuilder.withSearchArea(it) }
             areaBuilder.onVerticesChanged.add { areaBuilderDrawer.draw(areaBuilder) }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     repositories {
         google()
         jcenter()
-
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -24,20 +24,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-
-        maven {
-            url 'https://api.mapbox.com/downloads/v2/releases/maven'
-            authentication {
-                basic(BasicAuthentication)
-            }
-            credentials {
-                // This should always be `mapbox` (not the real username).
-                username = 'mapbox'
-                //Use Mapbox's secret key
-                password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ""
-            }
-        }
-
+        mavenCentral()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ buildscript {
     repositories {
         google()
         jcenter()
-        mavenCentral()
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -24,7 +24,19 @@ allprojects {
     repositories {
         google()
         jcenter()
-        mavenCentral()
+        maven {
+            url 'https://api.mapbox.com/downloads/v2/releases/maven'
+            authentication {
+                basic(BasicAuthentication)
+            }
+            credentials {
+                // This should always be `mapbox` (not the real username).
+                username = 'mapbox'
+                //Use Mapbox's secret key
+                password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ""
+            }
+        }
+
     }
 }
 


### PR DESCRIPTION
The bug: We were not able to drag the vertices on mapbox.
The fix: Downgrade "mapbox-android-plugin-annotation" and instanciate the circleManager responsible for the vertices as the last. So we must instanciate all drawers in itinaryCreation before the MapboxAreaBuilderDrawer.

Special thanks to @Ph0tonic for explaining me that the last instanciated manager should be the one with the draggable items.