### PR TITLE
Allow unlogged users access shared missions

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/MainActivityTest.kt
@@ -149,7 +149,7 @@ class MainActivityTest {
         onView(withId(R.id.browse_itinerary_button))
                 .perform(click())
         Intents.intended(
-                hasComponent(hasClassName(LoginActivity::class.java.name))
+                hasComponent(hasClassName(MappingMissionSelectionActivity::class.java.name))
         )
     }
 

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivityTest.kt
@@ -41,6 +41,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.not
 import org.hamcrest.core.AllOf.allOf
 import org.junit.*
 import org.junit.rules.RuleChain
@@ -322,6 +323,50 @@ class MappingMissionSelectionActivityTest {
         // Reset LIVE DATA
         SHARED_FILTERED_LIVE_DATA.postValue(emptyList())
         PRIVATE_FILTERED_LIVE_DATA.postValue(emptyList())
+    }
+
+    @Test
+    fun toggleButtonIsDisabledWhenNoUserConnected() {
+
+        `when`(authService.hasActiveSession()).thenReturn(false)
+
+        // Recreate the activity to apply the update
+        activityRule.scenario.recreate()
+
+        onView(withId(R.id.mapping_mission_state_toggle))
+            .check(matches(not(isEnabled())))
+    }
+
+    @Test
+    fun sharedMappingMissionLaunchShowItineraryWhenNoUserConnected() {
+
+        `when`(authService.hasActiveSession()).thenReturn(false)
+
+        // Recreate the activity to apply the update
+        activityRule.scenario.recreate()
+
+        onView(
+            allOf(
+                withText(buttonName(true, SHARED_MAPPING_MISSION)),
+                isDisplayed()
+            )
+        ).perform(click())
+        Intents.intended(
+            IntentMatchers.hasComponent(ComponentNameMatchers.hasClassName(ItineraryShowActivity::class.java.name))
+        )
+    }
+
+        @Test
+        fun privateMissionsAreNotShownWhenNoUserConnected() {
+
+            `when`(authService.hasActiveSession()).thenReturn(false)
+
+            // Recreate the activity to apply the update
+            activityRule.scenario.recreate()
+
+            onView(withId(R.id.private_mission_list_view))
+                .check(matches(not(isDisplayed())))
+
     }
 
     @Test

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivityTest.kt
@@ -32,6 +32,7 @@ import ch.epfl.sdp.drone3d.model.mission.MappingMission
 import ch.epfl.sdp.drone3d.model.mission.State
 import ch.epfl.sdp.drone3d.service.api.storage.dao.MappingMissionDao
 import ch.epfl.sdp.drone3d.service.module.MappingMissionDaoModule
+import ch.epfl.sdp.drone3d.ui.MainActivity
 import com.google.firebase.auth.FirebaseUser
 import com.mapbox.mapboxsdk.geometry.LatLng
 import dagger.hilt.android.testing.BindValue
@@ -72,9 +73,11 @@ class MappingMissionSelectionActivityTest {
         private val PRIVATE_FILTERED_LIVE_DATA = MutableLiveData(emptyList<MappingMission>())
     }
 
+    private val activityRule = ActivityScenarioRule(MappingMissionSelectionActivity::class.java)
+
     @get:Rule
     var testRule: RuleChain = RuleChain.outerRule(HiltAndroidRule(this))
-        .around(ActivityScenarioRule(MappingMissionSelectionActivity::class.java))
+        .around(activityRule)
 
     @BindValue
     val authService: AuthenticationService = mock(AuthenticationService::class.java)
@@ -88,6 +91,8 @@ class MappingMissionSelectionActivityTest {
         `when`(user.uid).thenReturn(USER_UID)
         val userSession = UserSession(user)
         `when`(authService.getCurrentSession()).thenReturn(userSession)
+        `when`(authService.hasActiveSession()).thenReturn(true)
+
 
         // Mock mapping mission dao
         `when`(mappingMissionDao.getPrivateMappingMissions(anyString()))
@@ -255,6 +260,7 @@ class MappingMissionSelectionActivityTest {
 
     @Test
     fun searchingChangesMissionsAndAreUpdatedWithLiveData() {
+
         // Semaphore used to wait for live data to be dispatched
         val mutex = Semaphore(0)
         // Make sure the current state is shared
@@ -320,6 +326,7 @@ class MappingMissionSelectionActivityTest {
 
     @Test
     fun clearTextInSearchBarShowsMissionWithoutFilter() {
+
         // Make sure the current state is shared
         var isPrivate = false
         // The filter that will be entered in the search bar

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/MainActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/MainActivity.kt
@@ -95,11 +95,7 @@ class MainActivity : AppCompatActivity() {
      * Go to MappingMissionSelectionActivity when browse_itinerary_button is clicked
      */
     fun goToMappingMissionSelection(@Suppress("UNUSED_PARAMETER") view: View) {
-        if (authService.hasActiveSession()) {
-            open(MappingMissionSelectionActivity::class)
-        } else {
-            goToLogin(view)
-        }
+        open(MappingMissionSelectionActivity::class)
     }
 
     /**

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivity.kt
@@ -151,62 +151,41 @@ class MappingMissionSelectionActivity : AppCompatActivity() {
 
     private fun setupListViews() {
 
+        val sharedList = findViewById<RecyclerView>(R.id.shared_mission_list_view)
+        val privateList = findViewById<RecyclerView>(R.id.private_mission_list_view)
+        val sharedFilteredList = findViewById<RecyclerView>(R.id.shared_filtered_mission_list_view)
+        val privateFilteredList =
+                findViewById<RecyclerView>(R.id.private_filtered_mission_list_view)
+
+        setupListAdapter(sharedList, false, false)
+        setupListAdapter(sharedFilteredList, false, true)
+
+        // Link state with view visibility
+        currentListState.observe(this, androidx.lifecycle.Observer {
+            it.let {
+                sharedList.visibility = getVisibility(false, false, it)
+                privateList.visibility = getVisibility(true, false, it)
+                sharedFilteredList.visibility = getVisibility(false, true, it)
+                privateFilteredList.visibility = getVisibility(true, true, it)
+
+                mappingMissionDao.updateSharedFilteredMappingMissions(it.second)
+            }
+        })
+
+
         if(authService.getCurrentSession() != null) {
             val ownerId = authService.getCurrentSession()!!.user.uid
 
-            val sharedList = findViewById<RecyclerView>(R.id.shared_mission_list_view)
-            val privateList = findViewById<RecyclerView>(R.id.private_mission_list_view)
-            val sharedFilteredList = findViewById<RecyclerView>(R.id.shared_filtered_mission_list_view)
-            val privateFilteredList =
-                    findViewById<RecyclerView>(R.id.private_filtered_mission_list_view)
-
-
-            setupListAdapter(sharedList, false, false)
             setupListAdapter(privateList, true, false)
-            setupListAdapter(sharedFilteredList, false, true)
             setupListAdapter(privateFilteredList, true, true)
 
             // Link state with view visibility
             currentListState.observe(this, androidx.lifecycle.Observer {
                 it.let {
-                    sharedList.visibility = getVisibility(false, false, it)
-                    privateList.visibility = getVisibility(true, false, it)
-                    sharedFilteredList.visibility = getVisibility(false, true, it)
-                    privateFilteredList.visibility = getVisibility(true, true, it)
-
-
-                    mappingMissionDao.updateSharedFilteredMappingMissions(it.second)
                     mappingMissionDao.updatePrivateFilteredMappingMissions(ownerId, it.second)
                 }
             })
 
-        }
-        else{
-
-            val sharedList = findViewById<RecyclerView>(R.id.shared_mission_list_view)
-            val sharedFilteredList = findViewById<RecyclerView>(R.id.shared_filtered_mission_list_view)
-            val privateList = findViewById<RecyclerView>(R.id.private_mission_list_view)
-            val privateFilteredList =
-                    findViewById<RecyclerView>(R.id.private_filtered_mission_list_view)
-
-            setupListAdapter(sharedList, false, false)
-            setupListAdapter(sharedFilteredList, false, true)
-
-            // Link state with view visibility
-            currentListState.observe(this, androidx.lifecycle.Observer {
-                it.let {
-                    sharedList.visibility = getVisibility(false, false, it)
-                    privateList.visibility = getVisibility(true, false, it)
-                    sharedFilteredList.visibility = getVisibility(false, true, it)
-                    privateFilteredList.visibility = getVisibility(true, true, it)
-
-                    mappingMissionDao.updateSharedFilteredMappingMissions(it.second)
-                }
-            })
-
-            currentListState.observe(this, androidx.lifecycle.Observer {
-                mappingMissionDao.updateSharedFilteredMappingMissions(it.second)
-            })
         }
 
     }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivity.kt
@@ -54,9 +54,9 @@ class MappingMissionSelectionActivity : AppCompatActivity() {
     private fun setupAdapter(
             data: LiveData<List<MappingMission>>,
             adapter: ListAdapter<MappingMission, out RecyclerView.ViewHolder>
-    ) = data.observe(this) {
+    ) = data.observe(this, androidx.lifecycle.Observer {
         it.let { adapter.submitList(sortedList(it)) }
-    }
+    })
 
 
     private fun sortedList(mappingMissions: List<MappingMission>?): List<MappingMission> {
@@ -111,18 +111,36 @@ class MappingMissionSelectionActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_mapping_mission_selection)
 
+
+        val selectedStorageTypeToggleButton =
+                findViewById<ToggleButton>(R.id.mapping_mission_state_toggle)
+
+
         setupListViews()
 
-        // Setup toggle button
-        val selectedStorageTypeToggleButton =
-            findViewById<ToggleButton>(R.id.mapping_mission_state_toggle)
-        selectedStorageTypeToggleButton.isChecked = currentListState.value!!.first.checked
-        selectedStorageTypeToggleButton.setOnCheckedChangeListener { _, isChecked ->
+        if(!authService.hasActiveSession()){
+
             currentListState.value =
-                Pair(
-                    if (isChecked) StorageType.PRIVATE else StorageType.SHARED,
-                    currentListState.value!!.second
-                )
+                    Pair(
+                            StorageType.SHARED,
+                            currentListState.value!!.second
+                    )
+
+
+
+            selectedStorageTypeToggleButton.isEnabled = false
+
+        }
+        else{
+
+            selectedStorageTypeToggleButton.isChecked = currentListState.value!!.first.checked
+            selectedStorageTypeToggleButton.setOnCheckedChangeListener { _, isChecked ->
+                currentListState.value =
+                        Pair(
+                                if (isChecked) StorageType.PRIVATE else StorageType.SHARED,
+                                currentListState.value!!.second
+                        )
+            }
         }
 
         val searchBar = findViewById<SearchView>(R.id.searchView)
@@ -132,31 +150,65 @@ class MappingMissionSelectionActivity : AppCompatActivity() {
     }
 
     private fun setupListViews() {
-        val ownerId = authService.getCurrentSession()!!.user.uid
 
-        val sharedList = findViewById<RecyclerView>(R.id.shared_mission_list_view)
-        val privateList = findViewById<RecyclerView>(R.id.private_mission_list_view)
-        val sharedFilteredList = findViewById<RecyclerView>(R.id.shared_filtered_mission_list_view)
-        val privateFilteredList =
-            findViewById<RecyclerView>(R.id.private_filtered_mission_list_view)
+        if(authService.getCurrentSession() != null) {
+            val ownerId = authService.getCurrentSession()!!.user.uid
 
-        setupListAdapter(sharedList, false, false)
-        setupListAdapter(privateList, true, false)
-        setupListAdapter(sharedFilteredList, false, true)
-        setupListAdapter(privateFilteredList, true, true)
+            val sharedList = findViewById<RecyclerView>(R.id.shared_mission_list_view)
+            val privateList = findViewById<RecyclerView>(R.id.private_mission_list_view)
+            val sharedFilteredList = findViewById<RecyclerView>(R.id.shared_filtered_mission_list_view)
+            val privateFilteredList =
+                    findViewById<RecyclerView>(R.id.private_filtered_mission_list_view)
 
-        // Link state with view visibility
-        currentListState.observe(this) {
-            it.let {
-                sharedList.visibility = getVisibility(false, false, it)
-                privateList.visibility = getVisibility(true, false, it)
-                sharedFilteredList.visibility = getVisibility(false, true, it)
-                privateFilteredList.visibility = getVisibility(true, true, it)
 
-                mappingMissionDao.updateSharedFilteredMappingMissions(it.second)
-                mappingMissionDao.updatePrivateFilteredMappingMissions(ownerId, it.second)
-            }
+            setupListAdapter(sharedList, false, false)
+            setupListAdapter(privateList, true, false)
+            setupListAdapter(sharedFilteredList, false, true)
+            setupListAdapter(privateFilteredList, true, true)
+
+            // Link state with view visibility
+            currentListState.observe(this, androidx.lifecycle.Observer {
+                it.let {
+                    sharedList.visibility = getVisibility(false, false, it)
+                    privateList.visibility = getVisibility(true, false, it)
+                    sharedFilteredList.visibility = getVisibility(false, true, it)
+                    privateFilteredList.visibility = getVisibility(true, true, it)
+
+
+                    mappingMissionDao.updateSharedFilteredMappingMissions(it.second)
+                    mappingMissionDao.updatePrivateFilteredMappingMissions(ownerId, it.second)
+                }
+            })
+
         }
+        else{
+
+            val sharedList = findViewById<RecyclerView>(R.id.shared_mission_list_view)
+            val sharedFilteredList = findViewById<RecyclerView>(R.id.shared_filtered_mission_list_view)
+            val privateList = findViewById<RecyclerView>(R.id.private_mission_list_view)
+            val privateFilteredList =
+                    findViewById<RecyclerView>(R.id.private_filtered_mission_list_view)
+
+            setupListAdapter(sharedList, false, false)
+            setupListAdapter(sharedFilteredList, false, true)
+
+            // Link state with view visibility
+            currentListState.observe(this, androidx.lifecycle.Observer {
+                it.let {
+                    sharedList.visibility = getVisibility(false, false, it)
+                    privateList.visibility = getVisibility(true, false, it)
+                    sharedFilteredList.visibility = getVisibility(false, true, it)
+                    privateFilteredList.visibility = getVisibility(true, true, it)
+
+                    mappingMissionDao.updateSharedFilteredMappingMissions(it.second)
+                }
+            })
+
+            currentListState.observe(this, androidx.lifecycle.Observer {
+                mappingMissionDao.updateSharedFilteredMappingMissions(it.second)
+            })
+        }
+
     }
 
     private fun getVisibility(
@@ -183,9 +235,8 @@ class MappingMissionSelectionActivity : AppCompatActivity() {
         private: Boolean,
         filter: Boolean
     ): LiveData<List<MappingMission>> {
-        val ownerId = authService.getCurrentSession()!!.user.uid
         return when {
-            private and !filter -> mappingMissionDao.getPrivateMappingMissions(ownerId)
+            private and !filter -> mappingMissionDao.getPrivateMappingMissions(authService.getCurrentSession()!!.user.uid)
             !private and !filter -> mappingMissionDao.getSharedMappingMissions()
             private and filter -> mappingMissionDao.getPrivateFilteredMappingMissions()
             else -> mappingMissionDao.getSharedFilteredMappingMissions()

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivity.kt
@@ -148,6 +148,11 @@ class MappingMissionSelectionActivity : AppCompatActivity() {
     }
 
     private fun setupListViews() {
+        /**
+         * Get the missions to show (shared if not connected, shared + private if user is connected)
+         * and make the list observe the currentListState to have the right visibility when we click
+         * on the toggle button
+         */
 
         val sharedList = findViewById<RecyclerView>(R.id.shared_mission_list_view)
         val privateList = findViewById<RecyclerView>(R.id.private_mission_list_view)

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivity.kt
@@ -126,8 +126,6 @@ class MappingMissionSelectionActivity : AppCompatActivity() {
                             currentListState.value!!.second
                     )
 
-
-
             selectedStorageTypeToggleButton.isEnabled = false
 
         }
@@ -179,7 +177,6 @@ class MappingMissionSelectionActivity : AppCompatActivity() {
             setupListAdapter(privateList, true, false)
             setupListAdapter(privateFilteredList, true, true)
 
-            // Link state with view visibility
             currentListState.observe(this, androidx.lifecycle.Observer {
                 it.let {
                     mappingMissionDao.updatePrivateFilteredMappingMissions(ownerId, it.second)

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivity.kt
@@ -128,8 +128,7 @@ class MappingMissionSelectionActivity : AppCompatActivity() {
 
             selectedStorageTypeToggleButton.isEnabled = false
 
-        }
-        else{
+        } else{
 
             selectedStorageTypeToggleButton.isChecked = currentListState.value!!.first.checked
             selectedStorageTypeToggleButton.setOnCheckedChangeListener { _, isChecked ->
@@ -147,12 +146,12 @@ class MappingMissionSelectionActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
+    /**
+     * Get the missions to show (shared if not connected, shared + private if user is connected)
+     * and make the list observe the currentListState to have the right visibility when we click
+     * on the toggle button
+     */
     private fun setupListViews() {
-        /**
-         * Get the missions to show (shared if not connected, shared + private if user is connected)
-         * and make the list observe the currentListState to have the right visibility when we click
-         * on the toggle button
-         */
 
         val sharedList = findViewById<RecyclerView>(R.id.shared_mission_list_view)
         val privateList = findViewById<RecyclerView>(R.id.private_mission_list_view)


### PR DESCRIPTION
Change in MappingMissionSelection to allow unlogged users to see and launch shared missions.