### PR TITLE
Implement a location permission service

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/service/location/AndroidLocationPermissionServiceTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/service/location/AndroidLocationPermissionServiceTest.kt
@@ -10,9 +10,9 @@ import android.content.pm.PackageManager
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.epfl.sdp.drone3d.service.api.location.LocationPermissionService.Companion.PERMISSION
+import ch.epfl.sdp.drone3d.service.api.location.LocationPermissionService.Companion.REQUEST_CODE
 import ch.epfl.sdp.drone3d.service.impl.location.AndroidLocationPermissionService
-import ch.epfl.sdp.drone3d.service.impl.location.AndroidLocationPermissionService.Companion.PERMISSION
-import ch.epfl.sdp.drone3d.service.impl.location.AndroidLocationPermissionService.Companion.REQUEST_CODE
 import ch.epfl.sdp.drone3d.ui.TempTestActivity
 import org.junit.Assert
 import org.junit.Rule
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+
 
 @RunWith(AndroidJUnit4::class)
 class AndroidLocationPermissionServiceTest {
@@ -81,9 +82,8 @@ class AndroidLocationPermissionServiceTest {
         }
     }
 
-/*  // Tried to test permission request popup but test running fails because of keyDispatchingTimedOut
     @Test
-    fun requestPermissionShowsRequest() {
+    fun requestPermissionWorksOnActivity() {
         `when`(context.checkSelfPermission(PERMISSION))
             .thenReturn(
                 PackageManager.PERMISSION_DENIED
@@ -92,15 +92,8 @@ class AndroidLocationPermissionServiceTest {
         // Launch an activity and request permission
         ActivityScenario.launch(TempTestActivity::class.java).onActivity { activity ->
             Assert.assertTrue(permissionService.requestPermission(activity))
-
-            // Check that a button which denies the permission appeared
-            if (Build.VERSION.SDK_INT >= 23) {
-                val device = UiDevice.getInstance(getInstrumentation())
-                val denyPermission = device.findObject(UiSelector().text("Deny"))
-                Assert.assertTrue(denyPermission.exists())
-            }
         }
     }
-*/
+
 
 }

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/service/location/AndroidLocationPermissionServiceTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/service/location/AndroidLocationPermissionServiceTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2021  Drone3D-Team
+ * The license can be found in LICENSE at root of the repository
+ */
+
+package ch.epfl.sdp.drone3d.service.location
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.epfl.sdp.drone3d.service.impl.location.AndroidLocationPermissionService
+import ch.epfl.sdp.drone3d.service.impl.location.AndroidLocationPermissionService.Companion.PERMISSION
+import ch.epfl.sdp.drone3d.service.impl.location.AndroidLocationPermissionService.Companion.REQUEST_CODE
+import ch.epfl.sdp.drone3d.ui.TempTestActivity
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+@RunWith(AndroidJUnit4::class)
+class AndroidLocationPermissionServiceTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val context = mock(Context::class.java)
+    private val permissionService = AndroidLocationPermissionService(context)
+
+    @Test
+    fun isPermissionGrantedIsTrueIfContextGrantsPermission() {
+        `when`(context.checkSelfPermission(PERMISSION))
+            .thenReturn(
+                PackageManager.PERMISSION_GRANTED
+            )
+        Assert.assertTrue(permissionService.isPermissionGranted())
+    }
+
+    @Test
+    fun isPermissionGrantedIsFalseIfContextDoesNotGrantPermission() {
+        `when`(context.checkSelfPermission(PERMISSION))
+            .thenReturn(
+                PackageManager.PERMISSION_DENIED
+            )
+        Assert.assertFalse(permissionService.isPermissionGranted())
+    }
+
+    @Test
+    fun noPermissionIsAskedIfPermissionIsGranted() {
+        `when`(context.checkSelfPermission(PERMISSION))
+            .thenReturn(
+                PackageManager.PERMISSION_GRANTED
+            )
+
+        // Launch an activity and request permission
+        ActivityScenario.launch(TempTestActivity::class.java).onActivity { activity ->
+            Assert.assertFalse(permissionService.requestPermission(activity))
+        }
+    }
+
+    @Test
+    fun noPermissionIsAskedTwice() {
+        `when`(context.checkSelfPermission(PERMISSION))
+            .thenReturn(
+                PackageManager.PERMISSION_DENIED
+            )
+
+        // Simulate the first request for permission by getting the permission results
+        permissionService.onRequestPermissionsResult(
+            REQUEST_CODE,
+            arrayOf(PERMISSION),
+            intArrayOf(PackageManager.PERMISSION_DENIED)
+        )
+
+        // Launch an activity and request permission
+        ActivityScenario.launch(TempTestActivity::class.java).onActivity { activity ->
+            Assert.assertFalse(permissionService.requestPermission(activity))
+        }
+    }
+
+/*  // Tried to test permission request popup but test running fails because of keyDispatchingTimedOut
+    @Test
+    fun requestPermissionShowsRequest() {
+        `when`(context.checkSelfPermission(PERMISSION))
+            .thenReturn(
+                PackageManager.PERMISSION_DENIED
+            )
+
+        // Launch an activity and request permission
+        ActivityScenario.launch(TempTestActivity::class.java).onActivity { activity ->
+            Assert.assertTrue(permissionService.requestPermission(activity))
+
+            // Check that a button which denies the permission appeared
+            if (Build.VERSION.SDK_INT >= 23) {
+                val device = UiDevice.getInstance(getInstrumentation())
+                val denyPermission = device.findObject(UiSelector().text("Deny"))
+                Assert.assertTrue(denyPermission.exists())
+            }
+        }
+    }
+*/
+
+}

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivityTest.kt
@@ -88,33 +88,6 @@ class ItineraryCreateActivityTest {
     }
 
     @Test
-    fun sendLocationPermissionAllowedEnablesLocation() {
-        var locationEnabled = true
-
-        activityRule.scenario.onActivity {
-            it.onRequestPermissionsResult(
-                0,
-                arrayOf("android.permission.ACCESS_FINE_LOCATION"),
-                intArrayOf(0)
-            )
-            locationEnabled =
-                it.locationComponentManager.mapboxMap.locationComponent.isLocationComponentEnabled
-        }
-        Assert.assertTrue(locationEnabled)
-    }
-
-    @Test
-    fun onExplanationNeededShowsToast() {
-        lateinit var activity: Activity
-        activityRule.scenario.onActivity {
-            activity = it
-            it.locationComponentManager.onExplanationNeeded(mutableListOf("android.permission.ACCESS_FINE_LOCATION"))
-        }
-        ToastMatcher.onToast(activity, R.string.user_location_permission_request)
-            .check(matches(isDisplayed()))
-    }
-
-    @Test
     fun goToSaveActivityButtonIsNotEnabledWhenUserNotLogin() {
         `when`(authService.hasActiveSession()).thenReturn(false)
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/map/gps/LocationComponentManager.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/map/gps/LocationComponentManager.kt
@@ -5,8 +5,10 @@
 
 package ch.epfl.sdp.drone3d.map.gps
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.widget.Toast
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.map.MapboxUtility
@@ -21,91 +23,62 @@ import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
 
 /**
- * The manager for map phone location
+ * The manager for showing the user location on a mapboxMap
  */
-class LocationComponentManager(private val activity: Activity, val mapboxMap: MapboxMap, val locationService: LocationService) :
-    PermissionsListener {
+class LocationComponentManager {
 
-    private var permissionsManager: PermissionsManager = PermissionsManager(this)
+    companion object {
 
-    private var style: Style? = null
+        /**
+         * Enables the location on the map given the loadedMapStyle
+         */
+        @SuppressLint("MissingPermission")
+        fun enableLocationComponent(
+            activity: Activity,
+            mapboxMap: MapboxMap,
+            locationService: LocationService
+        ) {
+            val style = mapboxMap.style
+            ActivityCompat.requestPermissions(activity, arrayOf(), 0)
+            // Check if permissions are enabled and if not request
+            if (locationService.isLocationEnabled() && style != null) {
 
-    /**
-     * Enables the location on the map given the loadedMapStyle
-     */
-    fun enableLocationComponent(loadedMapStyle: Style) {
-        style = loadedMapStyle
-        // Check if permissions are enabled and if not request
-        if (checkAndRequestLocationPermission()) {
-
-            // Create and customize the LocationComponent's options
-            val customLocationComponentOptions = LocationComponentOptions.builder(activity)
-                .trackingGesturesManagement(true)
-                .accuracyColor(ContextCompat.getColor(activity, R.color.blue))
-                .build()
-
-            val locationComponentActivationOptions =
-                LocationComponentActivationOptions.builder(activity, style!!)
-                    .locationComponentOptions(customLocationComponentOptions)
+                // Create and customize the LocationComponent's options
+                val customLocationComponentOptions = LocationComponentOptions.builder(activity)
+                    .trackingGesturesManagement(true)
+                    .accuracyColor(ContextCompat.getColor(activity, R.color.blue))
                     .build()
 
-            // Get an instance of the LocationComponent and then adjust its settings
-            mapboxMap.locationComponent.apply {
+                val locationComponentActivationOptions =
+                    LocationComponentActivationOptions.builder(activity, style)
+                        .locationComponentOptions(customLocationComponentOptions)
+                        .build()
 
-                // Activate the LocationComponent with options
-                activateLocationComponent(locationComponentActivationOptions)
+                // Get an instance of the LocationComponent and then adjust its settings
+                mapboxMap.locationComponent.apply {
 
-                // Enable to make the LocationComponent visible
-                isLocationComponentEnabled = true
+                    // Activate the LocationComponent with options
+                    activateLocationComponent(locationComponentActivationOptions)
 
-                // Set the LocationComponent's camera mode
-                cameraMode = CameraMode.TRACKING
+                    // Enable to make the LocationComponent visible
+                    isLocationComponentEnabled = true
 
-                // Set the LocationComponent's render mode
-                renderMode = RenderMode.COMPASS
+                    // Set the LocationComponent's camera mode
+                    cameraMode = CameraMode.TRACKING
+
+                    // Set the LocationComponent's render mode
+                    renderMode = RenderMode.COMPASS
+                }
+
+                if (locationService.isLocationEnabled() && locationService.getCurrentLocation() != null) {
+                    MapboxUtility.zoomOnCoordinate(
+                        locationService.getCurrentLocation()!!,
+                        mapboxMap
+                    )
+                }
             }
-
-            if (locationService.isLocationEnabled() && locationService.getCurrentLocation() != null) {
-                MapboxUtility.zoomOnCoordinate(locationService.getCurrentLocation()!!, mapboxMap)
-            }
         }
-    }
 
-    /**
-     * Sends the permissions results to the permission manager
-     */
-    fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<String>,
-        grantResults: IntArray
-    ) {
-        permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults)
-    }
-
-    private fun checkAndRequestLocationPermission(): Boolean {
-        if (PermissionsManager.areLocationPermissionsGranted(activity)) {
-            return true
-        }
-        permissionsManager = PermissionsManager(this)
-        permissionsManager.requestLocationPermissions(activity)
-        return false
-    }
-
-    override fun onExplanationNeeded(permissionsToExplain: MutableList<String>?) {
-        Toast.makeText(activity, R.string.user_location_permission_request, Toast.LENGTH_LONG)
-            .show()
-    }
-
-    override fun onPermissionResult(granted: Boolean) {
-        if (granted) {
-            enableLocationComponent(style!!)
-        } else {
-            Toast.makeText(
-                activity,
-                R.string.user_location_permission_not_granted,
-                Toast.LENGTH_LONG
-            ).show()
-        }
     }
 
 }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/api/location/LocationPermissionService.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/api/location/LocationPermissionService.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2021  Drone3D-Team
+ * The license can be found in LICENSE at root of the repository
+ */
+
+package ch.epfl.sdp.drone3d.service.api.location
+
+import android.app.Activity
+import android.content.Context
+
+interface LocationPermissionService {
+
+    fun isPermissionGranted(): Boolean
+
+    fun requestPermission(activity: Activity)
+
+    fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray)
+
+}

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/api/location/LocationPermissionService.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/api/location/LocationPermissionService.kt
@@ -5,14 +5,40 @@
 
 package ch.epfl.sdp.drone3d.service.api.location
 
+import android.Manifest
 import android.app.Activity
 
+/**
+ * This service manages the location permission
+ */
 interface LocationPermissionService {
 
+    companion object {
+        /**
+         * The permission that this service manages
+         */
+        const val PERMISSION = Manifest.permission.ACCESS_FINE_LOCATION
+
+        /**
+         * The request code for the location permission
+         */
+        const val REQUEST_CODE = 0
+    }
+
+    /**
+     * Returns true if the location permission is granted.
+     */
     fun isPermissionGranted(): Boolean
 
+    /**
+     * Requests the location permission on the [activity].
+     * Returns true if the permission was requested.
+     */
     fun requestPermission(activity: Activity): Boolean
 
+    /**
+     * Updates this service with the request results.
+     */
     fun onRequestPermissionsResult(
         requestCode: Int,
         permissions: Array<String>,

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/api/location/LocationPermissionService.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/api/location/LocationPermissionService.kt
@@ -6,14 +6,17 @@
 package ch.epfl.sdp.drone3d.service.api.location
 
 import android.app.Activity
-import android.content.Context
 
 interface LocationPermissionService {
 
     fun isPermissionGranted(): Boolean
 
-    fun requestPermission(activity: Activity)
+    fun requestPermission(activity: Activity): Boolean
 
-    fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray)
+    fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<String>,
+        grantResults: IntArray
+    )
 
 }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/location/AndroidLocationPermissionService.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/location/AndroidLocationPermissionService.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2021  Drone3D-Team
+ * The license can be found in LICENSE at root of the repository
+ */
+
+package ch.epfl.sdp.drone3d.service.impl.location
+
+import android.Manifest
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.app.ActivityCompat.requestPermissions
+import ch.epfl.sdp.drone3d.R
+import ch.epfl.sdp.drone3d.service.api.location.LocationPermissionService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class AndroidLocationPermissionService @Inject constructor(@ApplicationContext private val context: Context) :
+    LocationPermissionService {
+
+    private val permission = Manifest.permission.ACCESS_FINE_LOCATION
+    private val permissionRequestCode = 0
+    private var isPermissionGranted =
+        ActivityCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    private var isPermissionDenied = false
+
+    override fun isPermissionGranted(): Boolean {
+        return isPermissionGranted
+    }
+
+    override fun requestPermission(activity: Activity) {
+        if (!isPermissionGranted() && !isPermissionDenied) {
+            if (ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
+                val askPermissionAlert: AlertDialog.Builder = AlertDialog.Builder(activity)
+                askPermissionAlert.setTitle(R.string.permission_location_enable)
+                    .setMessage(R.string.permission_location_rationale)
+                    .setPositiveButton(R.string.permission_accept_button) { _, _ ->
+                        requestPermissions(activity, arrayOf(permission), permissionRequestCode)
+                    }
+                    .setNegativeButton(R.string.permission_deny_button) { _, _ ->
+                        isPermissionDenied = true
+                    }
+
+                askPermissionAlert.show()
+            } else {
+                requestPermissions(activity, arrayOf(permission), permissionRequestCode)
+            }
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<String>,
+        grantResults: IntArray
+    ) {
+        if (requestCode == permissionRequestCode && permissions.size == 1 && permissions[0] == permission) {
+            when (grantResults[0]) {
+                PackageManager.PERMISSION_GRANTED -> isPermissionGranted = true
+                PackageManager.PERMISSION_DENIED -> isPermissionDenied = true
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/location/AndroidLocationPermissionService.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/location/AndroidLocationPermissionService.kt
@@ -5,7 +5,6 @@
 
 package ch.epfl.sdp.drone3d.service.impl.location
 
-import android.Manifest
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.Context
@@ -14,16 +13,16 @@ import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityCompat.requestPermissions
 import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.service.api.location.LocationPermissionService
+import ch.epfl.sdp.drone3d.service.api.location.LocationPermissionService.Companion.PERMISSION
+import ch.epfl.sdp.drone3d.service.api.location.LocationPermissionService.Companion.REQUEST_CODE
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
+/**
+ * Location permission service using android permissions
+ */
 class AndroidLocationPermissionService @Inject constructor(@ApplicationContext private val context: Context) :
     LocationPermissionService {
-
-    companion object {
-        const val PERMISSION = Manifest.permission.ACCESS_FINE_LOCATION
-        const val REQUEST_CODE = 0
-    }
 
     private var isPermissionDenied = false
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/location/AndroidLocationService.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/location/AndroidLocationService.kt
@@ -5,18 +5,14 @@
 
 package ch.epfl.sdp.drone3d.service.impl.location
 
-import android.Manifest
 import android.annotation.SuppressLint
-import android.content.Context
-import android.content.pm.PackageManager
 import android.location.Criteria
 import android.location.LocationListener
 import android.location.LocationManager
-import androidx.core.app.ActivityCompat
+import ch.epfl.sdp.drone3d.service.api.location.LocationPermissionService
 import ch.epfl.sdp.drone3d.service.api.location.LocationService
 import ch.epfl.sdp.drone3d.service.module.LocationModule.LocationProvider
 import com.mapbox.mapboxsdk.geometry.LatLng
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 /**
@@ -26,7 +22,7 @@ class AndroidLocationService @Inject constructor(
     private val locationManager: LocationManager,
     @LocationProvider val locationProvider: String?,
     private val locationCriteria: Criteria,
-    @ApplicationContext private val context: Context
+    private val permissionService: LocationPermissionService
 ) : LocationService {
 
     private var listenerId = 1
@@ -37,9 +33,7 @@ class AndroidLocationService @Inject constructor(
     }
 
     override fun isLocationEnabled(): Boolean {
-        val currentPermission =
-            context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
-        return currentPermission == PackageManager.PERMISSION_GRANTED && getMyLocationProvider() != null
+        return permissionService.isPermissionGranted() && getMyLocationProvider() != null
     }
 
     // Permission is checked on isLocationEnabled()

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/module/LocationPermissionModule.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/module/LocationPermissionModule.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021  Drone3D-Team
+ * The license can be found in LICENSE at root of the repository
+ */
+
+package ch.epfl.sdp.drone3d.service.module
+
+import ch.epfl.sdp.drone3d.service.api.location.LocationPermissionService
+import ch.epfl.sdp.drone3d.service.impl.location.AndroidLocationPermissionService
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LocationPermissionModule {
+
+    @Singleton
+    @Binds
+    abstract fun bindLocationPermissionService(
+        locationPermissionServiceImpl: AndroidLocationPermissionService
+    ): LocationPermissionService
+
+}

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/MainActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.appcompat.app.AppCompatActivity
 import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.service.api.drone.DroneService
 import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
+import ch.epfl.sdp.drone3d.service.api.location.LocationPermissionService
 import ch.epfl.sdp.drone3d.ui.auth.LoginActivity
 import ch.epfl.sdp.drone3d.ui.drone.ConnectedDroneActivity
 import ch.epfl.sdp.drone3d.ui.drone.DroneConnectActivity
@@ -28,6 +29,9 @@ import kotlin.reflect.KClass
  */
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var permissionService: LocationPermissionService
 
     @Inject
     lateinit var authService: AuthenticationService
@@ -67,6 +71,7 @@ class MainActivity : AppCompatActivity() {
     override fun onStart() {
         super.onStart()
         refresh()
+        permissionService.requestPermission(this)
     }
 
     /**
@@ -103,7 +108,7 @@ class MainActivity : AppCompatActivity() {
      * depending of if a drone is connected or not
      */
     fun goToDroneConnect(@Suppress("UNUSED_PARAMETER") view: View) {
-        if(droneService.isConnected()) {
+        if (droneService.isConnected()) {
             open(ConnectedDroneActivity::class)
         } else {
             open(DroneConnectActivity::class)
@@ -113,5 +118,18 @@ class MainActivity : AppCompatActivity() {
     private fun <T> open(activity: KClass<T>) where T : Activity {
         val intent = Intent(this, activity.java)
         startActivity(intent)
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        permissionService.onRequestPermissionsResult(
+            requestCode,
+            permissions as Array<String>,
+            grantResults
+        )
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
@@ -10,7 +10,6 @@
 package ch.epfl.sdp.drone3d.ui.mission
 
 
-import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
@@ -55,9 +54,6 @@ class ItineraryCreateActivity : BaseMapActivity(), OnMapReadyCallback,
     // Button
     private lateinit var goToSaveButton: FloatingActionButton
 
-    // Location
-    lateinit var locationComponentManager: LocationComponentManager
-
     // Drawer
     private lateinit var missionDrawer: MapboxMissionDrawer
     private lateinit var areaBuilderDrawer: MapboxAreaBuilderDrawer
@@ -94,10 +90,9 @@ class ItineraryCreateActivity : BaseMapActivity(), OnMapReadyCallback,
     }
 
     override fun onMapReady(mapboxMap: MapboxMap) {
-        locationComponentManager = LocationComponentManager(this, mapboxMap, locationService)
-
         mapboxMap.setStyle(Style.MAPBOX_STREETS) { style ->
-            locationComponentManager.enableLocationComponent(style)
+            LocationComponentManager.enableLocationComponent(this, mapboxMap, locationService)
+            //configureLocationOptions(style)
 
             areaBuilder = PolygonBuilder()
             //areaBuilder = ParallelogramBuilder()
@@ -128,15 +123,6 @@ class ItineraryCreateActivity : BaseMapActivity(), OnMapReadyCallback,
             areaBuilder.onDestroy()
         }
         mapView.onDestroy()
-    }
-
-    @SuppressLint("MissingSuperCall")
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<String>,
-        grantResults: IntArray
-    ) {
-        locationComponentManager.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
     override fun onMapClick(position: LatLng): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,4 +92,10 @@
     <string name="drone_pause_error">Mission pause failed, try again later</string>
     <string name="drone_return_error">Could not launch mission to let the drone come back</string>
     <string name="drone_return_success">The drone is coming back</string>
+
+    <!-- Permission dialog -->
+    <string name="permission_accept_button">Accept</string>
+    <string name="permission_deny_button">Deny</string>
+    <string name="permission_location_enable">Enable location</string>
+    <string name="permission_location_rationale">In order to offer you the best possible experience, this app requires your location. Disabling it will result in some features not being available.</string>
 </resources>


### PR DESCRIPTION
Implement a location permission service which can be asked if the location permission is granted and request it. It will request the location permission only once in the menu if the permission isn't already granted. Update AndroidLocationService to make use of this service. Update create itinerary activity to check permission from this service and do not request permission.