### PR TITLE
Work squalene default drone properties

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/service/mission/ParallelogramMappingMissionServiceTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/service/mission/ParallelogramMappingMissionServiceTest.kt
@@ -46,7 +46,7 @@ class ParallelogramMappingMissionServiceTest {
     fun computeGroundImageDimensionReturnsExpected() {
 
         val flightHeight = 10.0
-        val groundImageDimension = mappingMissionService.computeGroundImageDimension(flightHeight)!!
+        val groundImageDimension = mappingMissionService.computeGroundImageDimension(flightHeight)
 
         val expected = GroundImageDim(5.0, 5.0)
         assertEquals(expected, groundImageDimension)
@@ -61,7 +61,7 @@ class ParallelogramMappingMissionServiceTest {
         val area = Parallelogram(vertices[1], vertices[0], vertices[2])
         val cameraAngle = 0.0
         val flightHeight = 100.0
-        val groundImageDim = mappingMissionService.computeGroundImageDimension(flightHeight)!!
+        val groundImageDim = mappingMissionService.computeGroundImageDimension(flightHeight)
 
         val expected = projector.toLatLngs(ParallelogramMissionBuilder.buildSinglePassMappingMission(
             vertices[0],
@@ -70,7 +70,7 @@ class ParallelogramMappingMissionServiceTest {
             flightHeight,
             groundImageDim
         ))
-        val obtained = mappingMissionService.buildSinglePassMappingMission(latLngVertices, flightHeight)!!
+        val obtained = mappingMissionService.buildSinglePassMappingMission(latLngVertices, flightHeight)
         for (i in expected.indices){
             assertEquals(expected[i].latitude,obtained[i].latitude,0.0001)
             assertEquals(expected[i].longitude,obtained[i].longitude,0.0001)
@@ -86,7 +86,7 @@ class ParallelogramMappingMissionServiceTest {
         val area = Parallelogram(vertices[1], vertices[0], vertices[2])
         val cameraAngle = 0.0
         val flightHeight = 100.0
-        val groundImageDim = mappingMissionService.computeGroundImageDimension(flightHeight)!!
+        val groundImageDim = mappingMissionService.computeGroundImageDimension(flightHeight)
 
         val expected = projector.toLatLngs(
             ParallelogramMissionBuilder.buildDoublePassMappingMission(
@@ -98,7 +98,7 @@ class ParallelogramMappingMissionServiceTest {
             )
         )
         val obtained =
-            mappingMissionService.buildDoublePassMappingMission(latLngVertices, flightHeight)!!
+            mappingMissionService.buildDoublePassMappingMission(latLngVertices, flightHeight)
         for (i in expected.indices) {
             assertEquals(expected[i].latitude, obtained[i].latitude, 0.0001)
             assertEquals(expected[i].longitude, obtained[i].longitude, 0.0001)

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/mission/ParallelogramMappingMissionService.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/mission/ParallelogramMappingMissionService.kt
@@ -5,6 +5,7 @@
 
 package ch.epfl.sdp.drone3d.service.impl.mission
 
+import android.util.Log
 import ch.epfl.sdp.drone3d.model.mission.*
 import ch.epfl.sdp.drone3d.service.api.drone.DroneService
 import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService
@@ -15,8 +16,13 @@ import javax.inject.Inject
 class ParallelogramMappingMissionService @Inject constructor(val droneService: DroneService): MappingMissionService {
 
     private val cameraAngle = 0.0 // Suppose the drone is looking down
+    //Those default data correspond to the Freefly Astro Quadrotor properties
+    private val defaultSensorWidth = 7.82f
+    private val defaultFocalLength = 24.0f
+    private val defaultImageWidth = 1280
+    private val defaultImageHeight = 720
 
-    override fun buildSinglePassMappingMission(vertices:List<LatLng>,flightHeight:Double): List<LatLng>? {
+    override fun buildSinglePassMappingMission(vertices:List<LatLng>,flightHeight:Double): List<LatLng> {
 
         return buildMappingMission(
             vertices,
@@ -25,7 +31,7 @@ class ParallelogramMappingMissionService @Inject constructor(val droneService: D
         )
     }
 
-    override fun buildDoublePassMappingMission(vertices:List<LatLng>,flightHeight:Double): List<LatLng>? {
+    override fun buildDoublePassMappingMission(vertices:List<LatLng>,flightHeight:Double): List<LatLng> {
         return buildMappingMission(
             vertices,
             flightHeight,
@@ -40,24 +46,19 @@ class ParallelogramMappingMissionService @Inject constructor(val droneService: D
                 startingPoint: Point, area: Parallelogram, cameraAngle: Double,
                 flightHeight: Double, groundImageDimension: GroundImageDim
         ) -> List<Point>
-    ): List<LatLng>? {
+    ): List<LatLng> {
 
         if(vertices.size!=3){
             throw IllegalArgumentException("A parallelogram should be determined by 3 vertices")
         }
 
-
         val groundImageDimension = computeGroundImageDimension(flightHeight)
 
-        return if (groundImageDimension != null) {
             val projector = SphereToPlaneProjector(vertices[0])
             val parallelogram = Parallelogram(projector.toPoint(vertices[1]), projector.toPoint(vertices[0]),
                 projector.toPoint(vertices[2]))
-            projector.toLatLngs(mappingFunction(projector.toPoint(vertices[0]),
+            return projector.toLatLngs(mappingFunction(projector.toPoint(vertices[0]),
                 parallelogram, cameraAngle, flightHeight, groundImageDimension))
-        } else {
-            null
-        }
     }
 
     /**
@@ -65,20 +66,17 @@ class ParallelogramMappingMissionService @Inject constructor(val droneService: D
      * and the camera properties provided by the drone
      * If a property is not provided by the drone, returns null
      */
-    fun computeGroundImageDimension(flightHeight: Double): GroundImageDim? {
+    fun computeGroundImageDimension(flightHeight: Double): GroundImageDim {
 
-        val sensorWidth = droneService.getData().getSensorSize().value?.horizontalSize //millimeters
-        val focalLength = droneService.getData().getFocalLength().value // millimeters
-        val imageWidth = droneService.getData().getCameraResolution().value?.width // pixels
-        val imageHeight = droneService.getData().getCameraResolution().value?.height // pixels
-        return if (sensorWidth != null && focalLength != null && imageWidth != null && imageHeight != null) {
-            // Ground Sampling Distance in meters/pixel
-            val GSD = (sensorWidth * flightHeight) / (focalLength * imageWidth)
-            val groundImageWidth = GSD * imageWidth // meters
-            val groundImageHeight = GSD * imageHeight // meters
-            GroundImageDim(groundImageWidth, groundImageHeight)
-        } else {
-            null
-        }
+        val sensorWidth = droneService.getData().getSensorSize().value?.horizontalSize?:defaultSensorWidth //millimeters
+        val focalLength = droneService.getData().getFocalLength().value?:defaultFocalLength // millimeters
+        val imageWidth = droneService.getData().getCameraResolution().value?.width?:defaultImageWidth // pixels
+        val imageHeight = droneService.getData().getCameraResolution().value?.height?:defaultImageHeight // pixels
+
+        // Ground Sampling Distance in meters/pixel
+        val GSD = (sensorWidth * flightHeight) / (focalLength * imageWidth)
+        val groundImageWidth = GSD * imageWidth // meters
+        val groundImageHeight = GSD * imageHeight // meters
+        return GroundImageDim(groundImageWidth, groundImageHeight)
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/mission/ParallelogramMappingMissionService.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/mission/ParallelogramMappingMissionService.kt
@@ -5,7 +5,6 @@
 
 package ch.epfl.sdp.drone3d.service.impl.mission
 
-import android.util.Log
 import ch.epfl.sdp.drone3d.model.mission.*
 import ch.epfl.sdp.drone3d.service.api.drone.DroneService
 import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/mission/ParallelogramMappingMissionService.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/mission/ParallelogramMappingMissionService.kt
@@ -15,12 +15,15 @@ import javax.inject.Inject
 
 class ParallelogramMappingMissionService @Inject constructor(val droneService: DroneService): MappingMissionService {
 
-    private val cameraAngle = 0.0 // Suppose the drone is looking down
-    //Those default data correspond to the Freefly Astro Quadrotor properties
-    private val defaultSensorWidth = 7.82f
-    private val defaultFocalLength = 24.0f
-    private val defaultImageWidth = 1280
-    private val defaultImageHeight = 720
+    companion object{
+        private val cameraAngle = 0.0 // Suppose the drone is looking down
+        //Those default data correspond to the Freefly Astro Quadrotor properties
+        private val defaultSensorWidth = 7.82f
+        private val defaultFocalLength = 24.0f
+        private val defaultImageWidth = 1280
+        private val defaultImageHeight = 720
+    }
+   
 
     override fun buildSinglePassMappingMission(vertices:List<LatLng>,flightHeight:Double): List<LatLng> {
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/mission/ParallelogramMappingMissionService.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/service/impl/mission/ParallelogramMappingMissionService.kt
@@ -16,14 +16,15 @@ import javax.inject.Inject
 class ParallelogramMappingMissionService @Inject constructor(val droneService: DroneService): MappingMissionService {
 
     companion object{
-        private val cameraAngle = 0.0 // Suppose the drone is looking down
+        private const val cameraAngle = 0.0 // Suppose the drone is looking down
+
         //Those default data correspond to the Freefly Astro Quadrotor properties
-        private val defaultSensorWidth = 7.82f
-        private val defaultFocalLength = 24.0f
-        private val defaultImageWidth = 1280
-        private val defaultImageHeight = 720
+        private const val defaultSensorWidth = 7.82f //millimeters
+        private const val defaultFocalLength = 24.0f //millimeters
+        private const val defaultImageWidth = 1280 //pixels
+        private const val defaultImageHeight = 720 //pixels
     }
-   
+
 
     override fun buildSinglePassMappingMission(vertices:List<LatLng>,flightHeight:Double): List<LatLng> {
 


### PR DESCRIPTION
I added default drone camera properties to use when the drone service is not available when building a mapping mission.