### PR TITLE
Store flightheight, area and startegy instead of flightpath in mapping mission

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/MainActivityTest.kt
@@ -75,7 +75,7 @@ class MainActivityTest {
         // If permission is true, it will not request permission
         `when`(permissionService.isPermissionGranted()).thenReturn(true)
 
-        val liveData = MutableLiveData(listOf(MappingMission("name", listOf())))
+        val liveData = MutableLiveData(listOf(MappingMission("name")))
         `when`(mappingMissionDao.getPrivateMappingMissions(anyString())).thenReturn(liveData)
         `when`(mappingMissionDao.getSharedMappingMissions()).thenReturn(liveData)
         `when`(mappingMissionDao.getPrivateFilteredMappingMissions()).thenReturn(liveData)

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/map/MissionInProgressActivityIntendedTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/map/MissionInProgressActivityIntendedTest.kt
@@ -72,7 +72,7 @@ class MissionInProgressActivityIntendedTest {
         Intent(ApplicationProvider.getApplicationContext(), MissionInProgressActivity::class.java).apply {
             putExtras(
                     Bundle().apply {
-                        putSerializable(MissionViewAdapter.MISSION_PATH, someLocationsList)
+                        putSerializable(ItineraryShowActivity.FLIGHTPATH_INTENT_PATH, someLocationsList)
                     }
             )
         }

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/map/MissionInProgressActivityIntendedTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/map/MissionInProgressActivityIntendedTest.kt
@@ -172,8 +172,8 @@ class MissionInProgressActivityIntendedTest {
         ToastMatcher.onToast(activity.get(), activity.get().getString(R.string.drone_mission_error, "test"))
 
         ViewMatchers.assertThat(
-            activityRule.scenario.state.toString(),
-            Matchers.equalTo(Lifecycle.State.DESTROYED.toString())
+            activityRule.scenario.state,
+            Matchers.equalTo(Lifecycle.State.DESTROYED)
         )
 
         missionEndFuture = CompletableFuture() //reset
@@ -203,8 +203,8 @@ class MissionInProgressActivityIntendedTest {
         Thread.sleep(500)
 
         ViewMatchers.assertThat(
-            activityRule.scenario.state.toString(),
-            Matchers.equalTo(Lifecycle.State.DESTROYED.toString())
+            activityRule.scenario.state,
+            Matchers.equalTo(Lifecycle.State.DESTROYED)
         )
 
 
@@ -235,10 +235,9 @@ class MissionInProgressActivityIntendedTest {
         Thread.sleep(500)
 
         ViewMatchers.assertThat(
-            activityRule.scenario.state.toString(),
-            Matchers.equalTo(Lifecycle.State.DESTROYED.toString())
+            activityRule.scenario.state,
+            Matchers.equalTo(Lifecycle.State.DESTROYED)
         )
-
 
         missionEndFuture = CompletableFuture() //reset
     }

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/map/MissionInProgressActivityIntendedTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/map/MissionInProgressActivityIntendedTest.kt
@@ -3,6 +3,7 @@ package ch.epfl.sdp.drone3d.ui.map
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
@@ -36,6 +37,7 @@ import io.mavsdk.mission.Mission
 import io.mavsdk.telemetry.Telemetry
 import io.reactivex.Completable
 import io.reactivex.schedulers.Schedulers
+import org.hamcrest.Matchers
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -169,9 +171,9 @@ class MissionInProgressActivityIntendedTest {
         Thread.sleep(500)
         ToastMatcher.onToast(activity.get(), activity.get().getString(R.string.drone_mission_error, "test"))
 
-        Intents.intended(
-                IntentMatchers.hasComponent(
-                        ComponentNameMatchers.hasClassName(ItineraryShowActivity::class.java.name))
+        ViewMatchers.assertThat(
+            activityRule.scenario.state.toString(),
+            Matchers.equalTo(Lifecycle.State.DESTROYED.toString())
         )
 
         missionEndFuture = CompletableFuture() //reset
@@ -200,10 +202,11 @@ class MissionInProgressActivityIntendedTest {
 
         Thread.sleep(500)
 
-        Intents.intended(
-            IntentMatchers.hasComponent(
-                ComponentNameMatchers.hasClassName(ItineraryShowActivity::class.java.name))
+        ViewMatchers.assertThat(
+            activityRule.scenario.state.toString(),
+            Matchers.equalTo(Lifecycle.State.DESTROYED.toString())
         )
+
 
         missionEndFuture = CompletableFuture() //reset
     }
@@ -231,10 +234,11 @@ class MissionInProgressActivityIntendedTest {
 
         Thread.sleep(500)
 
-        Intents.intended(
-            IntentMatchers.hasComponent(
-                ComponentNameMatchers.hasClassName(ItineraryShowActivity::class.java.name))
+        ViewMatchers.assertThat(
+            activityRule.scenario.state.toString(),
+            Matchers.equalTo(Lifecycle.State.DESTROYED.toString())
         )
+
 
         missionEndFuture = CompletableFuture() //reset
     }

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivityTest.kt
@@ -22,6 +22,7 @@ import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.map.MapboxUtility
 import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
 import ch.epfl.sdp.drone3d.service.api.location.LocationService
+import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService
 import ch.epfl.sdp.drone3d.service.drone.DroneInstanceMock
 import ch.epfl.sdp.drone3d.service.module.AuthenticationModule
 import ch.epfl.sdp.drone3d.service.module.DroneModule
@@ -139,6 +140,19 @@ class ItineraryCreateActivityTest {
     }
 
     @Test
+    fun saveButtonIsActivatedWhenAreaIsComplete() {
+        activityRule.scenario.recreate()
+
+        onView(withId(R.id.buttonToSaveActivity))
+            .check(matches(not(isEnabled())))
+
+        createMission()
+
+        onView(withId(R.id.buttonToSaveActivity))
+            .check(matches(isEnabled()))
+    }
+
+    @Test
     fun deleteButtonIsEnabledWhenThereIsSomethingToDelete() {
         activityRule.scenario.recreate()
 
@@ -232,7 +246,9 @@ class ItineraryCreateActivityTest {
         )
 
         val intents = Intents.getIntents()
-        assert(intents.any { it.hasExtra("flightPath") })
+        assert(intents.any { it.hasExtra(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH) })
+        assert(intents.any { it.hasExtra(ItineraryCreateActivity.STRATEGY_INTENT_PATH) })
+        assert(intents.any { it.hasExtra(ItineraryCreateActivity.AREA_INTENT_PATH) })
     }
 
     @Test

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivityTest.kt
@@ -141,6 +141,8 @@ class ItineraryCreateActivityTest {
 
     @Test
     fun saveButtonIsActivatedWhenAreaIsComplete() {
+        `when`(authService.hasActiveSession()).thenReturn(true)
+
         activityRule.scenario.recreate()
 
         onView(withId(R.id.buttonToSaveActivity))

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivityTest.kt
@@ -45,12 +45,10 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import io.mavsdk.mission.Mission
 import io.reactivex.Completable
-import org.hamcrest.Matchers
 import org.junit.*
 import org.junit.rules.RuleChain
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
-import java.lang.Thread.sleep
 import java.util.*
 
 @HiltAndroidTest

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivityTest.kt
@@ -207,8 +207,6 @@ class ItineraryShowActivityTest {
         }
 
         onView(withId(R.id.buttonToMissionInProgressActivity)).perform(click())
-
-
     }
 
     @Test
@@ -250,7 +248,7 @@ class ItineraryShowActivityTest {
         onView(withId(R.id.buttonToMissionInProgressActivity))
             .check(matches(isEnabled()))
         onView(withId(R.id.buttonToMissionInProgressActivity)).perform(click())
-        
+
         Intents.intended(
             hasComponent(hasClassName(MissionInProgressActivity::class.java.name))
         )

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivityTest.kt
@@ -51,24 +51,39 @@ import org.mockito.Mockito.`when`
 import java.util.*
 
 @HiltAndroidTest
-@UninstallModules(DroneModule::class, AuthenticationModule::class, LocationModule::class, WeatherModule::class)
+@UninstallModules(
+    DroneModule::class,
+    AuthenticationModule::class,
+    LocationModule::class,
+    WeatherModule::class
+)
 class ItineraryShowActivityTest {
 
-    private val GOOD_WEATHER_REPORT = WeatherReport("Clear", "description",
-        20.0, 20, 5.0, 500, Date(12903))
+    private val GOOD_WEATHER_REPORT = WeatherReport(
+        "Clear", "description",
+        20.0, 20, 5.0, 500, Date(12903)
+    )
 
-    private val BAD_WEATHER_REPORT = WeatherReport("RAIN", "description",
-        -1.0, 20, 10.0, 500, Date(12903))
+    private val BAD_WEATHER_REPORT = WeatherReport(
+        "RAIN", "description",
+        -1.0, 20, 10.0, 500, Date(12903)
+    )
 
     private val USER_UID = "asdfg"
 
-    private val someLocationsList = arrayListOf(LatLng(47.398979, 8.543434))
+    private val bayland_area = arrayListOf(
+        LatLng(37.41253570576311, -121.99694775011824),
+        LatLng(37.412496825414046, -121.99683107403213),
+        LatLng(37.41243024942702, -121.99686795440418)
+    )
 
     private val activityRule = ActivityScenarioRule<ItineraryShowActivity>(
-        Intent(ApplicationProvider.getApplicationContext(),
-            ItineraryShowActivity::class.java).apply {
+        Intent(
+            ApplicationProvider.getApplicationContext(),
+            ItineraryShowActivity::class.java
+        ).apply {
             putExtras(Bundle().apply {
-                putSerializable(MissionViewAdapter.MISSION_PATH, someLocationsList)
+                putSerializable(MissionViewAdapter.AREA_INTENT_PATH, bayland_area)
             })
         }
     )
@@ -101,11 +116,20 @@ class ItineraryShowActivityTest {
         `when`(droneService.getData().getRelativeAltitude()).thenReturn(MutableLiveData())
         `when`(droneService.getData().getBatteryLevel()).thenReturn(MutableLiveData())
 
-        `when`(weatherService.getWeatherReport(someLocationsList[0])).thenReturn(MutableLiveData(GOOD_WEATHER_REPORT))
+        `when`(weatherService.getWeatherReport(bayland_area[0])).thenReturn(
+            MutableLiveData(
+                GOOD_WEATHER_REPORT
+            )
+        )
 
         val executor = Mockito.mock(DroneExecutor::class.java)
         `when`(droneService.getExecutor()).thenReturn(executor)
-        `when`(executor.startMission(anyObj(Context::class.java), anyObj(Mission.MissionPlan::class.java)))
+        `when`(
+            executor.startMission(
+                anyObj(Context::class.java),
+                anyObj(Mission.MissionPlan::class.java)
+            )
+        )
             .thenReturn(Completable.never())
         `when`(executor.returnToHomeLocationAndLand(anyObj(Context::class.java)))
             .thenReturn(Completable.complete())
@@ -133,9 +157,15 @@ class ItineraryShowActivityTest {
     @Test
     fun goToMissionInProgressActivityButtonIsNotEnabledWhenDroneIsNotConnected() {
         `when`(droneService.isConnected()).thenReturn(false)
-        `when`(droneService.getData()
-            .getPosition()).thenReturn(MutableLiveData(someLocationsList[0]))
-        `when`(weatherService.getWeatherReport(someLocationsList[0])).thenReturn(MutableLiveData(GOOD_WEATHER_REPORT))
+        `when`(
+            droneService.getData()
+                .getPosition()
+        ).thenReturn(MutableLiveData(bayland_area[0]))
+        `when`(weatherService.getWeatherReport(bayland_area[0])).thenReturn(
+            MutableLiveData(
+                GOOD_WEATHER_REPORT
+            )
+        )
 
         activityRule.scenario.recreate()
 
@@ -147,7 +177,11 @@ class ItineraryShowActivityTest {
     fun goToMissionProgressActivityButtonIsNotEnabledWhenDroneTooFar() {
         `when`(droneService.isConnected()).thenReturn(true)
         `when`(droneService.getData().getPosition()).thenReturn(MutableLiveData(LatLng(70.1, 40.3)))
-        `when`(weatherService.getWeatherReport(someLocationsList[0])).thenReturn(MutableLiveData(GOOD_WEATHER_REPORT))
+        `when`(weatherService.getWeatherReport(bayland_area[0])).thenReturn(
+            MutableLiveData(
+                GOOD_WEATHER_REPORT
+            )
+        )
 
         activityRule.scenario.recreate()
 
@@ -158,9 +192,15 @@ class ItineraryShowActivityTest {
     @Test
     fun goToMissionProgressActivityButtonIsEnabledWhenWeatherTooBad() {
         `when`(droneService.isConnected()).thenReturn(true)
-        `when`(droneService.getData()
-            .getPosition()).thenReturn(MutableLiveData(someLocationsList[0]))
-        `when`(weatherService.getWeatherReport(someLocationsList[0])).thenReturn(MutableLiveData(BAD_WEATHER_REPORT))
+        `when`(
+            droneService.getData()
+                .getPosition()
+        ).thenReturn(MutableLiveData(bayland_area[0]))
+        `when`(weatherService.getWeatherReport(bayland_area[0])).thenReturn(
+            MutableLiveData(
+                BAD_WEATHER_REPORT
+            )
+        )
 
         activityRule.scenario.recreate()
 
@@ -172,9 +212,15 @@ class ItineraryShowActivityTest {
     fun goToMissionInProgressActivityWork() {
         `when`(droneService.isConnected()).thenReturn(true)
         `when`(locationService.isLocationEnabled()).thenReturn(false)
-        `when`(droneService.getData()
-            .getPosition()).thenReturn(MutableLiveData(someLocationsList[0]))
-        `when`(weatherService.getWeatherReport(someLocationsList[0])).thenReturn(MutableLiveData(GOOD_WEATHER_REPORT))
+        `when`(
+            droneService.getData()
+                .getPosition()
+        ).thenReturn(MutableLiveData(bayland_area[0]))
+        `when`(weatherService.getWeatherReport(bayland_area[0])).thenReturn(
+            MutableLiveData(
+                GOOD_WEATHER_REPORT
+            )
+        )
 
         activityRule.scenario.recreate()
 
@@ -187,16 +233,22 @@ class ItineraryShowActivityTest {
         )
 
         val intents = Intents.getIntents()
-        assert(intents.any { it.hasExtra(MissionViewAdapter.MISSION_PATH) })
+        assert(intents.any { it.hasExtra(ItineraryShowActivity.FLIGHTPATH_INTENT_PATH) })
     }
 
     @Test
     fun goToMissionInProgressWorksWhenBadWeather() {
         `when`(droneService.isConnected()).thenReturn(true)
         `when`(locationService.isLocationEnabled()).thenReturn(false)
-        `when`(droneService.getData()
-            .getPosition()).thenReturn(MutableLiveData(someLocationsList[0]))
-        `when`(weatherService.getWeatherReport(someLocationsList[0])).thenReturn(MutableLiveData(BAD_WEATHER_REPORT))
+        `when`(
+            droneService.getData()
+                .getPosition()
+        ).thenReturn(MutableLiveData(bayland_area[0]))
+        `when`(weatherService.getWeatherReport(bayland_area[0])).thenReturn(
+            MutableLiveData(
+                BAD_WEATHER_REPORT
+            )
+        )
 
         activityRule.scenario.recreate()
 
@@ -214,7 +266,7 @@ class ItineraryShowActivityTest {
         )
 
         val intents = Intents.getIntents()
-        assert(intents.any { it.hasExtra(MissionViewAdapter.MISSION_PATH) })
+        assert(intents.any { it.hasExtra(ItineraryShowActivity.FLIGHTPATH_INTENT_PATH) })
 
     }
 
@@ -236,9 +288,11 @@ class ItineraryShowActivityTest {
         val userSession = UserSession(user)
         `when`(authService.getCurrentSession()).thenReturn(userSession)
 
-        val intent = Intent(ApplicationProvider.getApplicationContext(),
-            ItineraryShowActivity::class.java)
-        intent.putExtra(MissionViewAdapter.OWNER, USER_UID)
+        val intent = Intent(
+            ApplicationProvider.getApplicationContext(),
+            ItineraryShowActivity::class.java
+        )
+        intent.putExtra(MissionViewAdapter.OWNER_ID_INTENT_PATH, USER_UID)
 
         ActivityScenario.launch<ItineraryShowActivity>(intent).use { _ ->
             onView(withId(R.id.mission_delete))

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivityTest.kt
@@ -183,9 +183,6 @@ class ItineraryShowActivityTest {
         }
 
         onView(withId(R.id.buttonToMissionInProgressActivity)).perform(click())
-
-
-
     }
 
 

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivityTest.kt
@@ -27,6 +27,7 @@ import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
 import ch.epfl.sdp.drone3d.service.api.drone.DroneExecutor
 import ch.epfl.sdp.drone3d.service.api.drone.DroneService
 import ch.epfl.sdp.drone3d.service.api.location.LocationService
+import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService
 import ch.epfl.sdp.drone3d.service.api.weather.WeatherService
 import ch.epfl.sdp.drone3d.service.drone.DroneInstanceMock
 import ch.epfl.sdp.drone3d.service.module.AuthenticationModule
@@ -59,23 +60,27 @@ import java.util.*
 )
 class ItineraryShowActivityTest {
 
-    private val GOOD_WEATHER_REPORT = WeatherReport(
-        "Clear", "description",
-        20.0, 20, 5.0, 500, Date(12903)
-    )
+    companion object{
+        private val GOOD_WEATHER_REPORT = WeatherReport(
+            "Clear", "description",
+            20.0, 20, 5.0, 500, Date(12903)
+        )
 
-    private val BAD_WEATHER_REPORT = WeatherReport(
-        "RAIN", "description",
-        -1.0, 20, 10.0, 500, Date(12903)
-    )
+        private val BAD_WEATHER_REPORT = WeatherReport(
+            "RAIN", "description",
+            -1.0, 20, 10.0, 500, Date(12903)
+        )
 
-    private val USER_UID = "asdfg"
+        private val USER_UID = "asdfg"
 
-    private val bayland_area = arrayListOf(
-        LatLng(37.41253570576311, -121.99694775011824),
-        LatLng(37.412496825414046, -121.99683107403213),
-        LatLng(37.41243024942702, -121.99686795440418)
-    )
+        private val bayland_area = arrayListOf(
+            LatLng(37.41253570576311, -121.99694775011824),
+            LatLng(37.412496825414046, -121.99683107403213),
+            LatLng(37.41243024942702, -121.99686795440418)
+        )
+    }
+
+
 
     private val activityRule = ActivityScenarioRule<ItineraryShowActivity>(
         Intent(
@@ -84,6 +89,8 @@ class ItineraryShowActivityTest {
         ).apply {
             putExtras(Bundle().apply {
                 putSerializable(MissionViewAdapter.AREA_INTENT_PATH, bayland_area)
+                putSerializable(MissionViewAdapter.FLIGHTHEIGHT_INTENT_PATH, 50.0)
+                putSerializable(MissionViewAdapter.STRATEGY_INTENT_PATH, MappingMissionService.Strategy.SINGLE_PASS)
             })
         }
     )

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivityTest.kt
@@ -30,6 +30,7 @@ import ch.epfl.sdp.drone3d.model.mission.MappingMission
 import ch.epfl.sdp.drone3d.model.mission.State
 import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
 import ch.epfl.sdp.drone3d.service.api.drone.DroneService
+import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService
 import ch.epfl.sdp.drone3d.service.api.storage.dao.MappingMissionDao
 import ch.epfl.sdp.drone3d.service.drone.DroneInstanceMock
 import ch.epfl.sdp.drone3d.service.module.AuthenticationModule
@@ -61,10 +62,24 @@ class MappingMissionSelectionActivityTest {
 
     companion object {
         private const val USER_UID = "asdfg"
-
+        private val bayland_area = listOf(
+            LatLng(37.41253570576311, -121.99694775011824),
+            LatLng(37.412496825414046, -121.99683107403213),
+            LatLng(37.41243024942702, -121.99686795440418)
+        )
         private val SHARED_MAPPING_MISSION =
-            MappingMission("shared1")
-        private val PRIVATE_MAPPING_MISSION = MappingMission("private1")
+            MappingMission(
+                "shared1",
+                50.0,
+                MappingMissionService.Strategy.SINGLE_PASS,
+                bayland_area
+            )
+        private val PRIVATE_MAPPING_MISSION = MappingMission(
+            "private1",
+            50.0,
+            MappingMissionService.Strategy.SINGLE_PASS,
+            bayland_area
+        )
         private val PRIVATE_AND_SHARED_MAPPING_MISSION =
             MappingMission("private2").apply {
                 state = State.PRIVATE_AND_SHARED
@@ -124,6 +139,9 @@ class MappingMissionSelectionActivityTest {
         // Mock the position of the drone
         `when`(droneService.getData().getPosition()).thenReturn(MutableLiveData(LatLng(70.1, 40.3)))
         `when`(droneService.getData().isConnected()).thenReturn(MutableLiveData(true))
+        `when`(droneService.getData().getSensorSize()).thenReturn(MutableLiveData())
+        `when`(droneService.getData().getFocalLength()).thenReturn(MutableLiveData())
+        `when`(droneService.getData().getCameraResolution()).thenReturn(MutableLiveData())
     }
 
     @Before

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/MappingMissionSelectionActivityTest.kt
@@ -63,10 +63,10 @@ class MappingMissionSelectionActivityTest {
         private const val USER_UID = "asdfg"
 
         private val SHARED_MAPPING_MISSION =
-            MappingMission("shared1", listOf(LatLng(10.0, 10.0), LatLng(25.0, 25.0)))
-        private val PRIVATE_MAPPING_MISSION = MappingMission("private1", listOf())
+            MappingMission("shared1")
+        private val PRIVATE_MAPPING_MISSION = MappingMission("private1")
         private val PRIVATE_AND_SHARED_MAPPING_MISSION =
-            MappingMission("private2", listOf()).apply {
+            MappingMission("private2").apply {
                 state = State.PRIVATE_AND_SHARED
             }
 

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivityTest.kt
@@ -5,47 +5,38 @@
 
 package ch.epfl.sdp.drone3d.ui.mission
 
-import android.app.Activity
 import android.content.Intent
+import android.os.Bundle
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.MutableLiveData
-import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.ComponentNameMatchers
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import ch.epfl.sdp.drone3d.R
-import ch.epfl.sdp.drone3d.matcher.ToastMatcher
-import ch.epfl.sdp.drone3d.service.module.AuthenticationModule
-import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
 import ch.epfl.sdp.drone3d.model.auth.UserSession
 import ch.epfl.sdp.drone3d.model.mission.MappingMission
+import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
 import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService
 import ch.epfl.sdp.drone3d.service.api.storage.dao.MappingMissionDao
+import ch.epfl.sdp.drone3d.service.module.AuthenticationModule
 import ch.epfl.sdp.drone3d.service.module.MappingMissionDaoModule
-import ch.epfl.sdp.drone3d.ui.MainActivity
-import ch.epfl.sdp.drone3d.ui.TempTestActivity
 import com.google.firebase.auth.FirebaseUser
 import com.mapbox.mapboxsdk.geometry.LatLng
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
-import junit.framework.Assert.assertTrue
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
 import org.junit.*
 import org.junit.rules.RuleChain
 import org.mockito.Mockito
 import org.mockito.Mockito.*
-import java.util.concurrent.CompletableFuture
 
 @HiltAndroidTest
 @UninstallModules(AuthenticationModule::class, MappingMissionDaoModule::class)
@@ -55,7 +46,21 @@ class SaveMappingMissionActivityTest {
         private const val USER_UID = "user_id"
     }
 
-    private val activityRule = ActivityScenarioRule(SaveMappingMissionActivity::class.java)
+    private val activityRule = ActivityScenarioRule<SaveMappingMissionActivity>(
+        Intent(
+            ApplicationProvider.getApplicationContext(),
+            SaveMappingMissionActivity::class.java
+        ).apply {
+            putExtras(Bundle().apply {
+                putSerializable(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH, 0.0)
+                putSerializable(
+                    ItineraryCreateActivity.STRATEGY_INTENT_PATH,
+                    MappingMissionService.Strategy.SINGLE_PASS
+                )
+                putSerializable(ItineraryCreateActivity.AREA_INTENT_PATH, arrayListOf<LatLng>())
+            })
+        }
+    )
 
     @get:Rule
     val testRule: RuleChain = RuleChain.outerRule(HiltAndroidRule(this))
@@ -72,8 +77,18 @@ class SaveMappingMissionActivityTest {
     private fun mockMappingMissionDao(): MappingMissionDao {
         val mappingMissionDao = mock(MappingMissionDao::class.java)
 
-        `when`(mappingMissionDao.shareMappingMission(anyString(), any(MappingMission::class.java))).thenReturn(MutableLiveData(true))
-        `when`(mappingMissionDao.storeMappingMission(anyString(), any(MappingMission::class.java))).thenReturn(MutableLiveData(true))
+        `when`(
+            mappingMissionDao.shareMappingMission(
+                anyString(),
+                any(MappingMission::class.java)
+            )
+        ).thenReturn(MutableLiveData(true))
+        `when`(
+            mappingMissionDao.storeMappingMission(
+                anyString(),
+                any(MappingMission::class.java)
+            )
+        ).thenReturn(MutableLiveData(true))
 
         return mappingMissionDao
     }
@@ -118,16 +133,13 @@ class SaveMappingMissionActivityTest {
             "Unnamed mission"
         )
 
-        val intent = Intent(
-            ApplicationProvider.getApplicationContext(),
-            SaveMappingMissionActivity::class.java
-        )
-        ActivityScenario.launch<Activity>(intent)
-
         onView(withId(R.id.privateCheckBox)).perform(click())
         onView(withId(R.id.saveButton)).perform(click())
 
-        assertThat(activityRule.scenario.state.toString(), equalTo(Lifecycle.State.DESTROYED.toString()))
+        assertThat(
+            activityRule.scenario.state.toString(),
+            equalTo(Lifecycle.State.DESTROYED.toString())
+        )
 
         verify(mappingMissionDao, times(1)).storeMappingMission(USER_UID, expectedMappingMission)
     }
@@ -136,13 +148,15 @@ class SaveMappingMissionActivityTest {
     fun saveMappingMissionToShareCallShare() {
         activityRule.scenario.recreate()
 
-
         val expectedMappingMission = MappingMission("Unnamed mission")
 
         onView(withId(R.id.sharedCheckBox)).perform(click())
         onView(withId(R.id.saveButton)).perform(click())
 
-        assertThat(activityRule.scenario.state.toString(), equalTo(Lifecycle.State.DESTROYED.toString()))
+        assertThat(
+            activityRule.scenario.state.toString(),
+            equalTo(Lifecycle.State.DESTROYED.toString())
+        )
 
         verify(mappingMissionDao, times(1)).shareMappingMission(USER_UID, expectedMappingMission)
     }
@@ -157,7 +171,10 @@ class SaveMappingMissionActivityTest {
         onView(withId(R.id.privateCheckBox)).perform(click())
         onView(withId(R.id.saveButton)).perform(click())
 
-        assertThat(activityRule.scenario.state.toString(), equalTo(Lifecycle.State.DESTROYED.toString()))
+        assertThat(
+            activityRule.scenario.state.toString(),
+            equalTo(Lifecycle.State.DESTROYED.toString())
+        )
 
         verify(mappingMissionDao, times(1)).shareMappingMission(USER_UID, expectedMappingMission)
         verify(mappingMissionDao, times(1)).storeMappingMission(USER_UID, expectedMappingMission)
@@ -171,15 +188,6 @@ class SaveMappingMissionActivityTest {
 
         val expectedMappingMission = MappingMission(name)
 
-        val intent = Intent(
-            ApplicationProvider.getApplicationContext(),
-            SaveMappingMissionActivity::class.java
-        )
-        intent.putExtra(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH, 0.0)
-        intent.putExtra(ItineraryCreateActivity.AREA_INTENT_PATH, arrayListOf<LatLng>())
-        intent.putExtra(ItineraryCreateActivity.STRATEGY_INTENT_PATH, MappingMissionService.Strategy.SINGLE_PASS)
-        ActivityScenario.launch<Activity>(intent)
-
         onView(withId(R.id.missionName)).perform(click()).perform(
             typeText(
                 name
@@ -189,8 +197,11 @@ class SaveMappingMissionActivityTest {
         onView(withId(R.id.privateCheckBox)).perform(click())
         onView(withId(R.id.saveButton)).perform(click())
 
-        assertThat(activityRule.scenario.state.toString(), equalTo(Lifecycle.State.DESTROYED.toString()))
-        
+        assertThat(
+            activityRule.scenario.state.toString(),
+            equalTo(Lifecycle.State.DESTROYED.toString())
+        )
+
         verify(mappingMissionDao, times(1)).storeMappingMission(USER_UID, expectedMappingMission)
     }
 

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivityTest.kt
@@ -27,6 +27,7 @@ import ch.epfl.sdp.drone3d.service.module.AuthenticationModule
 import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
 import ch.epfl.sdp.drone3d.model.auth.UserSession
 import ch.epfl.sdp.drone3d.model.mission.MappingMission
+import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService
 import ch.epfl.sdp.drone3d.service.api.storage.dao.MappingMissionDao
 import ch.epfl.sdp.drone3d.service.module.MappingMissionDaoModule
 import ch.epfl.sdp.drone3d.ui.MainActivity
@@ -111,8 +112,7 @@ class SaveMappingMissionActivityTest {
 
     @Test
     fun saveMappingMissionToPrivateCallStore() {
-
-        val flightPath = arrayListOf(LatLng(10.1, 12.2), LatLng(1.1, 1.2))
+        activityRule.scenario.recreate()
 
         val expectedMappingMission = MappingMission(
             "Unnamed mission"
@@ -122,7 +122,6 @@ class SaveMappingMissionActivityTest {
             ApplicationProvider.getApplicationContext(),
             SaveMappingMissionActivity::class.java
         )
-        intent.putExtra("flightPath", flightPath)
         ActivityScenario.launch<Activity>(intent)
 
         onView(withId(R.id.privateCheckBox)).perform(click())
@@ -135,17 +134,10 @@ class SaveMappingMissionActivityTest {
 
     @Test
     fun saveMappingMissionToShareCallShare() {
+        activityRule.scenario.recreate()
 
-        val flightPath = arrayListOf(LatLng(10.1, 12.2), LatLng(1.1, 1.2))
 
         val expectedMappingMission = MappingMission("Unnamed mission")
-
-        val intent = Intent(
-            ApplicationProvider.getApplicationContext(),
-            SaveMappingMissionActivity::class.java
-        )
-        intent.putExtra("flightPath", flightPath)
-        ActivityScenario.launch<Activity>(intent)
 
         onView(withId(R.id.sharedCheckBox)).perform(click())
         onView(withId(R.id.saveButton)).perform(click())
@@ -157,17 +149,9 @@ class SaveMappingMissionActivityTest {
 
     @Test
     fun saveMappingMissionToShareAndPrivateCallShareAndStore() {
-
-        val flightPath = arrayListOf(LatLng(10.1, 12.2), LatLng(1.1, 1.2))
+        activityRule.scenario.recreate()
 
         val expectedMappingMission = MappingMission("Unnamed mission")
-
-        val intent = Intent(
-            ApplicationProvider.getApplicationContext(),
-            SaveMappingMissionActivity::class.java
-        )
-        intent.putExtra("flightPath", flightPath)
-        ActivityScenario.launch<Activity>(intent)
 
         onView(withId(R.id.sharedCheckBox)).perform(click())
         onView(withId(R.id.privateCheckBox)).perform(click())
@@ -181,8 +165,8 @@ class SaveMappingMissionActivityTest {
 
     @Test
     fun nameIsCorrect() {
+        activityRule.scenario.recreate()
 
-        val flightPath = arrayListOf<LatLng>()
         val name = "My mission"
 
         val expectedMappingMission = MappingMission(name)
@@ -191,7 +175,9 @@ class SaveMappingMissionActivityTest {
             ApplicationProvider.getApplicationContext(),
             SaveMappingMissionActivity::class.java
         )
-        intent.putExtra("flightPath", flightPath)
+        intent.putExtra(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH, 0.0)
+        intent.putExtra(ItineraryCreateActivity.AREA_INTENT_PATH, arrayListOf<LatLng>())
+        intent.putExtra(ItineraryCreateActivity.STRATEGY_INTENT_PATH, MappingMissionService.Strategy.SINGLE_PASS)
         ActivityScenario.launch<Activity>(intent)
 
         onView(withId(R.id.missionName)).perform(click()).perform(
@@ -211,6 +197,8 @@ class SaveMappingMissionActivityTest {
 
     @Test
     fun checkBoxesEnableSaveButton() {
+        activityRule.scenario.recreate()
+
         onView(withId(R.id.privateCheckBox))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
         onView(withId(R.id.sharedCheckBox))

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivityTest.kt
@@ -137,8 +137,8 @@ class SaveMappingMissionActivityTest {
         onView(withId(R.id.saveButton)).perform(click())
 
         assertThat(
-            activityRule.scenario.state.toString(),
-            equalTo(Lifecycle.State.DESTROYED.toString())
+            activityRule.scenario.state,
+            equalTo(Lifecycle.State.DESTROYED)
         )
 
         verify(mappingMissionDao, times(1)).storeMappingMission(USER_UID, expectedMappingMission)
@@ -154,8 +154,8 @@ class SaveMappingMissionActivityTest {
         onView(withId(R.id.saveButton)).perform(click())
 
         assertThat(
-            activityRule.scenario.state.toString(),
-            equalTo(Lifecycle.State.DESTROYED.toString())
+            activityRule.scenario.state,
+            equalTo(Lifecycle.State.DESTROYED)
         )
 
         verify(mappingMissionDao, times(1)).shareMappingMission(USER_UID, expectedMappingMission)

--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivityTest.kt
@@ -115,8 +115,7 @@ class SaveMappingMissionActivityTest {
         val flightPath = arrayListOf(LatLng(10.1, 12.2), LatLng(1.1, 1.2))
 
         val expectedMappingMission = MappingMission(
-            "Unnamed mission",
-            flightPath
+            "Unnamed mission"
         )
 
         val intent = Intent(
@@ -139,7 +138,7 @@ class SaveMappingMissionActivityTest {
 
         val flightPath = arrayListOf(LatLng(10.1, 12.2), LatLng(1.1, 1.2))
 
-        val expectedMappingMission = MappingMission("Unnamed mission", flightPath)
+        val expectedMappingMission = MappingMission("Unnamed mission")
 
         val intent = Intent(
             ApplicationProvider.getApplicationContext(),
@@ -161,7 +160,7 @@ class SaveMappingMissionActivityTest {
 
         val flightPath = arrayListOf(LatLng(10.1, 12.2), LatLng(1.1, 1.2))
 
-        val expectedMappingMission = MappingMission("Unnamed mission", flightPath)
+        val expectedMappingMission = MappingMission("Unnamed mission")
 
         val intent = Intent(
             ApplicationProvider.getApplicationContext(),
@@ -186,7 +185,7 @@ class SaveMappingMissionActivityTest {
         val flightPath = arrayListOf<LatLng>()
         val name = "My mission"
 
-        val expectedMappingMission = MappingMission(name, flightPath)
+        val expectedMappingMission = MappingMission(name)
 
         val intent = Intent(
             ApplicationProvider.getApplicationContext(),

--- a/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxMissionDrawer.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxMissionDrawer.kt
@@ -26,13 +26,6 @@ class MapboxMissionDrawer(mapView: MapView, mapboxMap: MapboxMap, style: Style):
     private var reset = true
 
     /**
-     * Show a [mission] on the map by linking all points with lines.
-     */
-    fun showMission(mission: MappingMission, withIndex : Boolean) {
-        showMission(mission.flightPath, withIndex)
-    }
-
-    /**
      * Show a [flightPath] on the map by linking all points with lines.
      */
     fun showMission(flightPath: List<LatLng>, withIndex : Boolean) {

--- a/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxUtility.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/map/MapboxUtility.kt
@@ -23,7 +23,7 @@ class MapboxUtility {
          * Zoom on the first step of a mission [mission] on the map [mapboxMap].
          */
         fun zoomOnMission(mission: MappingMission, mapboxMap: MapboxMap) {
-            zoomOnMission(mission.flightPath, mapboxMap)
+            zoomOnMission(mission.area, mapboxMap)
         }
 
         /**

--- a/app/src/main/java/ch/epfl/sdp/drone3d/model/mission/MappingMission.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/model/mission/MappingMission.kt
@@ -5,6 +5,7 @@
 
 package ch.epfl.sdp.drone3d.model.mission
 
+import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService.Strategy
 import com.mapbox.mapboxsdk.geometry.LatLng
 
 
@@ -21,14 +22,15 @@ enum class State {
 }
 
 /**
- * A MappingMission is instantiated with a [name], a [flightPath] and a [flightHeight].
+ * A MappingMission is instantiated with a [name], a [flightHeight], a [strategy] and a [area].
  * The [privateId], [sharedId] and [state] are updated according to where the MappingMission are stored.
  * The [ownerUid] is set the first time the mission is either stored or shared.
  */
 data class MappingMission(
     val name: String = "",
-    val flightPath: List<LatLng> = listOf(),
-    val flightHeight:Double = 0.0,
+    val flightHeight: Double = 0.0,
+    val strategy: Strategy = Strategy.SINGLE_PASS,
+    val area: List<LatLng> = listOf(),
     var privateId: String? = null,
     var sharedId: String? = null,
     var state: State = State.NOT_STORED,

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/map/MissionInProgressActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/map/MissionInProgressActivity.kt
@@ -94,7 +94,7 @@ class MissionInProgressActivity : BaseMapActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        missionPath = intent.getParcelableArrayListExtra(MissionViewAdapter.MISSION_PATH)
+        missionPath = intent.getParcelableArrayListExtra(ItineraryShowActivity.FLIGHTPATH_INTENT_PATH)
 
         initMapView(savedInstanceState,
             R.layout.activity_mission_in_progress,
@@ -178,25 +178,19 @@ class MissionInProgressActivity : BaseMapActivity() {
 
                 disposables.add(
                     completable.subscribe(
-                            { openItineraryShow() },
+                            { finish() },
                             {
                                 showError(it)
-                                openItineraryShow()
+                                finish()
                             })
                 )
             } catch (e: Exception) {
                 showError(e)
-                openItineraryShow()
+                finish()
             }
         }
     }
 
-    private fun openItineraryShow() {
-        val intent = Intent(this, ItineraryShowActivity::class.java)
-        intent.putExtra(MissionViewAdapter.MISSION_PATH, missionPath)
-        startActivity(intent)
-        finish()
-    }
 
     private fun setupObservers() {
         val droneData = droneService.getData()
@@ -321,7 +315,7 @@ class MissionInProgressActivity : BaseMapActivity() {
         createObserver(droneData.isConnected()) {
             if (it == null || !it) {
                 ToastHandler.showToastAsync(this, R.string.lost_connection_message, Toast.LENGTH_SHORT)
-                openItineraryShow()
+                finish()
             }
         }
     }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
@@ -306,9 +306,11 @@ class ItineraryCreateActivity : BaseMapActivity(), OnMapReadyCallback,
      */
     private fun goToSaveActivity() {
         val intent = Intent(this, SaveMappingMissionActivity::class.java)
-        intent.putExtra(MissionViewAdapter.FLIGHTHEIGHT_INTENT_PATH, flightHeight)
-        intent.putExtra(MissionViewAdapter.AREA_INTENT_PATH, ArrayList(areaBuilder.vertices))
-        intent.putExtra(MissionViewAdapter.STRATEGY_INTENT_PATH, strategy)
+        intent.putExtra(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH, flightHeight)
+        intent.putExtra(ItineraryCreateActivity.AREA_INTENT_PATH, ArrayList(areaBuilder.vertices))
+        //intent.putExtra(ItineraryCreateActivity.STRATEGY_INTENT_PATH, strategy.name)
+        intent.putExtra(ItineraryCreateActivity.STRATEGY_INTENT_PATH, strategy)
+
         startActivity(intent)
     }
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
@@ -17,7 +17,6 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.res.ResourcesCompat
-import androidx.lifecycle.LiveData
 import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.map.MapboxAreaBuilderDrawer
 import ch.epfl.sdp.drone3d.map.MapboxMissionDrawer
@@ -25,8 +24,6 @@ import ch.epfl.sdp.drone3d.map.area.AreaBuilder
 import ch.epfl.sdp.drone3d.map.area.ParallelogramBuilder
 import ch.epfl.sdp.drone3d.map.gps.LocationComponentManager
 import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
-import ch.epfl.sdp.drone3d.service.api.drone.DroneData
-import ch.epfl.sdp.drone3d.service.api.drone.DroneExecutor
 import ch.epfl.sdp.drone3d.service.api.drone.DroneService
 import ch.epfl.sdp.drone3d.service.api.location.LocationService
 import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService.Strategy
@@ -39,9 +36,6 @@ import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
 import com.mapbox.mapboxsdk.maps.Style
 import dagger.hilt.android.AndroidEntryPoint
-import io.mavsdk.System
-import io.mavsdk.mission.Mission
-import io.mavsdk.telemetry.Telemetry
 import javax.inject.Inject
 
 /**
@@ -92,7 +86,7 @@ class ItineraryCreateActivity : BaseMapActivity(), OnMapReadyCallback,
     // Text
     private lateinit var altitudeText: TextView
 
-    companion object{
+    companion object {
         const val STRATEGY_INTENT_PATH = "ICA_strategy"
         const val AREA_INTENT_PATH = "ICA_area"
         const val FLIGHTHEIGHT_INTENT_PATH = "ICA_flightHeight"
@@ -146,10 +140,11 @@ class ItineraryCreateActivity : BaseMapActivity(), OnMapReadyCallback,
             mapboxMap.addOnMapClickListener(this)
 
             // Buttons
-            altitudeText.text = flightHeight.toString() + "m"
+
+            altitudeText.text = getString(R.string.altitude_text, flightHeight)
             altitudeButton.setOnProgressChangeListener { progressValue ->
                 flightHeight = progressValue.toDouble()
-                altitudeText.text = progressValue.toString() + "m"
+                altitudeText.text = getString(R.string.altitude_text, flightHeight)
                 onMissionSettingModified()
             }
         }
@@ -251,17 +246,11 @@ class ItineraryCreateActivity : BaseMapActivity(), OnMapReadyCallback,
                     )
                 }
 
-                if (path != null) {
-                    flightPath = ArrayList(path)
-                    if (isMissionDisplayed) {
-                        missionDrawer.showMission(flightPath, false)
-                    }
-                } else {
-                    Toast.makeText(
-                        baseContext, R.string.drone_should_be_connected,
-                        Toast.LENGTH_SHORT
-                    ).show()
+                flightPath = ArrayList(path)
+                if (isMissionDisplayed) {
+                    missionDrawer.showMission(flightPath, false)
                 }
+
             }
         }
     }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivity.kt
@@ -308,7 +308,6 @@ class ItineraryCreateActivity : BaseMapActivity(), OnMapReadyCallback,
         val intent = Intent(this, SaveMappingMissionActivity::class.java)
         intent.putExtra(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH, flightHeight)
         intent.putExtra(ItineraryCreateActivity.AREA_INTENT_PATH, ArrayList(areaBuilder.vertices))
-        //intent.putExtra(ItineraryCreateActivity.STRATEGY_INTENT_PATH, strategy.name)
         intent.putExtra(ItineraryCreateActivity.STRATEGY_INTENT_PATH, strategy)
 
         startActivity(intent)

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
@@ -76,7 +76,7 @@ class ItineraryShowActivity : BaseMapActivity() {
         //Create a "back button" in the action bar up
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        readIntent()
+        extractExtras()
 
         mapView.getMapAsync { mapboxMap ->
             mapboxMap.setStyle(Style.MAPBOX_STREETS) {
@@ -110,7 +110,7 @@ class ItineraryShowActivity : BaseMapActivity() {
         }
     }
 
-    private fun readIntent() {
+    private fun extractExtras() {
         val bundle = intent.extras
         if (bundle != null) {
             // Get the Intent that started this activity and extract user and ids

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
@@ -95,7 +95,7 @@ class ItineraryShowActivity : BaseMapActivity() {
                         area,
                         flightHeight
                     )
-                }!!
+                }
                 missionDrawer.showMission(flightPath, false)
                 MapboxUtility.zoomOnMission(flightPath, mapboxMap)
             }
@@ -107,11 +107,10 @@ class ItineraryShowActivity : BaseMapActivity() {
         weatherReport = weatherService.getWeatherReport(area[0])
         weatherReport.observe(this) {
             isWeatherGoodEnough = WeatherUtils.isWeatherGoodEnough(it)
-
         }
     }
 
-    private fun readIntent(){
+    private fun readIntent() {
         val bundle = intent.extras
         if (bundle != null) {
             // Get the Intent that started this activity and extract user and ids

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
@@ -16,8 +16,10 @@ import ch.epfl.sdp.drone3d.map.MapboxUtility
 import ch.epfl.sdp.drone3d.model.weather.WeatherReport
 import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
 import ch.epfl.sdp.drone3d.service.api.drone.DroneService
+import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService
 import ch.epfl.sdp.drone3d.service.api.storage.dao.MappingMissionDao
 import ch.epfl.sdp.drone3d.service.api.weather.WeatherService
+import ch.epfl.sdp.drone3d.service.impl.mission.ParallelogramMappingMissionService
 import ch.epfl.sdp.drone3d.service.impl.weather.WeatherUtils
 import ch.epfl.sdp.drone3d.ui.map.BaseMapActivity
 import ch.epfl.sdp.drone3d.ui.map.MissionInProgressActivity
@@ -37,6 +39,7 @@ class ItineraryShowActivity : BaseMapActivity() {
     companion object {
         // max 1000 meters between the user/simulation and the start of the mission
         private const val MAX_BEGINNING_DISTANCE = 1000
+        const val FLIGHTPATH_INTENT_PATH = "ISA_flightPath"
     }
 
     @Inject
@@ -48,12 +51,16 @@ class ItineraryShowActivity : BaseMapActivity() {
     @Inject
     lateinit var  weatherService: WeatherService
 
-    private var currentMissionPath: ArrayList<LatLng>? = null
+    // TODO remove
+    private var flightPath = listOf<LatLng>()
     private lateinit var missionDrawer: MapboxMissionDrawer
 
     private lateinit var ownerUid: String
     private var privateId: String? = null
     private var sharedId: String? = null
+    private lateinit var area: List<LatLng>
+    private lateinit var strategy: MappingMissionService.Strategy
+    private var flightHeight: Double = 50.0
 
     // true if the weather is good enough to launch the mission
     private var isWeatherGoodEnough: Boolean = false
@@ -71,12 +78,16 @@ class ItineraryShowActivity : BaseMapActivity() {
         //Create a "back button" in the action bar up
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        // Get the Intent that started this activity and extract the missionPath
-        currentMissionPath = intent.getParcelableArrayListExtra(MissionViewAdapter.MISSION_PATH)
-        // Get the Intent that started this activity and extract user and ids
-        ownerUid = intent.getStringExtra(MissionViewAdapter.OWNER).toString()
-        privateId = intent.getStringExtra(MissionViewAdapter.PRIVATE)
-        sharedId = intent.getStringExtra(MissionViewAdapter.SHARED)
+        val bundle = intent.extras
+        if(bundle != null){
+            // Get the Intent that started this activity and extract user and ids
+            ownerUid = intent.getStringExtra(MissionViewAdapter.OWNER_ID_INTENT_PATH).toString()
+            privateId = intent.getStringExtra(MissionViewAdapter.PRIVATE_ID_INTENT_PATH)
+            sharedId = intent.getStringExtra(MissionViewAdapter.SHARED_ID_INTENT_PATH)
+            flightHeight = bundle.getDouble(MissionViewAdapter.FLIGHTHEIGHT_INTENT_PATH)!!
+            strategy = (bundle.get(MissionViewAdapter.STRATEGY_INTENT_PATH) as MappingMissionService.Strategy?)!!
+            area = bundle.getParcelableArrayList(MissionViewAdapter.AREA_INTENT_PATH)!!
+        }
 
         mapView.getMapAsync { mapboxMap ->
             mapboxMap.setStyle(Style.MAPBOX_STREETS) {
@@ -85,18 +96,27 @@ class ItineraryShowActivity : BaseMapActivity() {
                     missionDrawer = MapboxMissionDrawer(mapView, mapboxMap, mapboxMap.style!!)
                 }
 
-                if (currentMissionPath != null) {
-                    missionDrawer.showMission(currentMissionPath!!, false)
-                    MapboxUtility.zoomOnMission(currentMissionPath!!, mapboxMap)
-                }
+                val missionBuilder = ParallelogramMappingMissionService(droneService)
+                flightPath = when (strategy) {
+                    MappingMissionService.Strategy.SINGLE_PASS -> missionBuilder.buildSinglePassMappingMission(
+                        area,
+                        flightHeight
+                    )
+                    MappingMissionService.Strategy.DOUBLE_PASS -> missionBuilder.buildDoublePassMappingMission(
+                        area,
+                        flightHeight
+                    )
+                }!!
+                missionDrawer.showMission(flightPath, false)
+                    MapboxUtility.zoomOnMission(flightPath, mapboxMap)
             }
         }
 
         findViewById<View>(R.id.mission_delete).visibility =
             if (authService.getCurrentSession()?.user?.uid == ownerUid) View.VISIBLE else View.GONE
 
-        if (currentMissionPath != null && currentMissionPath!!.isNotEmpty()) {
-            weatherReport = weatherService.getWeatherReport(LatLng(currentMissionPath!![0]))
+        if (flightPath.isNotEmpty()) {
+            weatherReport = weatherService.getWeatherReport(LatLng(flightPath[0]))
             weatherReport.observe(this) {
                 isWeatherGoodEnough = WeatherUtils.isWeatherGoodEnough(it)
             }
@@ -121,10 +141,10 @@ class ItineraryShowActivity : BaseMapActivity() {
      */
     private fun canMissionBeLaunched(): Boolean {
         val dronePos = droneService.getData().getPosition().value
-        return if (currentMissionPath?.isEmpty() == true || !droneService.isConnected() || dronePos == null)
+        return if (flightPath.isEmpty() == true || !droneService.isConnected() || dronePos == null)
             false
         else {
-            val beginningPoint = currentMissionPath!![0]
+            val beginningPoint = flightPath[0]
             dronePos.distanceTo(beginningPoint) < MAX_BEGINNING_DISTANCE
         }
     }
@@ -154,7 +174,7 @@ class ItineraryShowActivity : BaseMapActivity() {
 
     private fun goToMissionInProgressActivity(){
         val intent = Intent(this, MissionInProgressActivity::class.java)
-        intent.putExtra(MissionViewAdapter.MISSION_PATH, currentMissionPath)
+        intent.putExtra(FLIGHTPATH_INTENT_PATH, ArrayList(flightPath))
         startActivity(intent)
     }
 
@@ -182,7 +202,7 @@ class ItineraryShowActivity : BaseMapActivity() {
      */
     fun goToWeatherInfo(@Suppress("UNUSED_PARAMETER")view: View) {
         val intent = Intent(this, WeatherInfoActivity::class.java)
-        intent.putExtra(MissionViewAdapter.MISSION_PATH, currentMissionPath)
+        intent.putExtra(FLIGHTPATH_INTENT_PATH, ArrayList(flightPath))
         startActivity(intent)
     }
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
@@ -76,17 +76,7 @@ class ItineraryShowActivity : BaseMapActivity() {
         //Create a "back button" in the action bar up
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        val bundle = intent.extras
-        if (bundle != null) {
-            // Get the Intent that started this activity and extract user and ids
-            ownerUid = intent.getStringExtra(MissionViewAdapter.OWNER_ID_INTENT_PATH).toString()
-            privateId = intent.getStringExtra(MissionViewAdapter.PRIVATE_ID_INTENT_PATH)
-            sharedId = intent.getStringExtra(MissionViewAdapter.SHARED_ID_INTENT_PATH)
-            flightHeight = bundle.getDouble(MissionViewAdapter.FLIGHTHEIGHT_INTENT_PATH)
-            strategy =
-                (bundle.get(MissionViewAdapter.STRATEGY_INTENT_PATH) as MappingMissionService.Strategy?)!!
-            area = bundle.getParcelableArrayList(MissionViewAdapter.AREA_INTENT_PATH)!!
-        }
+        readIntent()
 
         mapView.getMapAsync { mapboxMap ->
             mapboxMap.setStyle(Style.MAPBOX_STREETS) {
@@ -118,6 +108,20 @@ class ItineraryShowActivity : BaseMapActivity() {
         weatherReport.observe(this) {
             isWeatherGoodEnough = WeatherUtils.isWeatherGoodEnough(it)
 
+        }
+    }
+
+    private fun readIntent(){
+        val bundle = intent.extras
+        if (bundle != null) {
+            // Get the Intent that started this activity and extract user and ids
+            ownerUid = intent.getStringExtra(MissionViewAdapter.OWNER_ID_INTENT_PATH).toString()
+            privateId = intent.getStringExtra(MissionViewAdapter.PRIVATE_ID_INTENT_PATH)
+            sharedId = intent.getStringExtra(MissionViewAdapter.SHARED_ID_INTENT_PATH)
+            flightHeight = bundle.getDouble(MissionViewAdapter.FLIGHTHEIGHT_INTENT_PATH)
+            strategy =
+                (bundle.get(MissionViewAdapter.STRATEGY_INTENT_PATH) as MappingMissionService.Strategy?)!!
+            area = bundle.getParcelableArrayList(MissionViewAdapter.AREA_INTENT_PATH)!!
         }
     }
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
@@ -8,7 +8,6 @@ package ch.epfl.sdp.drone3d.ui.mission
 import android.app.AlertDialog.Builder
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.lifecycle.LiveData
 import ch.epfl.sdp.drone3d.R

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryShowActivity.kt
@@ -126,24 +126,22 @@ class ItineraryShowActivity : BaseMapActivity() {
      * Start an intent to go to the mission in progress activity
      */
     fun launchMission(@Suppress("UNUSED_PARAMETER") view: View) {
-        if (!isWeatherGoodEnough) {
+        val dronePos = droneService.getData().getPosition().value
+        val beginningPoint = flightPath[0]
+        if (!droneService.isConnected()) {
+            ToastHandler.showToast(this, R.string.launch_no_drone)
+        } else if (dronePos == null) {
+            ToastHandler.showToast(this, R.string.launch_no_drone_pos)
+        } else if (dronePos.distanceTo(beginningPoint) > MAX_BEGINNING_DISTANCE) {
+            ToastHandler.showToast(this, R.string.drone_too_far_from_start)
+        } else if (!isWeatherGoodEnough) {
             val builder = Builder(this)
             builder.setMessage(getString(R.string.launch_mission_confirmation))
             builder.setCancelable(true)
 
             builder.setPositiveButton(getString(R.string.confirm_launch)) { dialog, _ ->
                 dialog.cancel()
-                val dronePos = droneService.getData().getPosition().value
-                val beginningPoint = flightPath[0]
-                if (!droneService.isConnected()) {
-                    ToastHandler.showToast(this, R.string.launch_no_drone)
-                } else if (dronePos == null) {
-                    ToastHandler.showToast(this, R.string.launch_no_drone_pos)
-                } else if (dronePos.distanceTo(beginningPoint) > MAX_BEGINNING_DISTANCE) {
-                    ToastHandler.showToast(this, R.string.drone_too_far_from_start)
-                } else {
-                    goToMissionInProgressActivity()
-                }
+                goToMissionInProgressActivity()
             }
 
             builder.setNegativeButton(R.string.cancel_launch) { dialog, _ ->

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MissionViewAdapter.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MissionViewAdapter.kt
@@ -25,10 +25,12 @@ class MissionViewAdapter(private val privateList: Boolean) :
         ListAdapter<MappingMission, MissionViewAdapter.MissionViewHolder>(MissionDiff) {
 
     companion object{
-        const val MISSION_PATH = "ch.epfl.sdp.drone3d.ui.mission.MAPPING_MISSION"
-        const val OWNER = "owner"
-        const val PRIVATE = "private"
-        const val SHARED = "shared"
+        const val OWNER_ID_INTENT_PATH = "MVA_owner"
+        const val PRIVATE_ID_INTENT_PATH = "MVA_private"
+        const val SHARED_ID_INTENT_PATH = "MVA_shared"
+        const val STRATEGY_INTENT_PATH = "MVA_strategy"
+        const val AREA_INTENT_PATH = "MVA_area"
+        const val FLIGHTHEIGHT_INTENT_PATH = "MVA_flightHeight"
     }
 
     class MissionViewHolder(view: View, private val privateList: Boolean) : RecyclerView.ViewHolder(view) {
@@ -40,12 +42,13 @@ class MissionViewAdapter(private val privateList: Boolean) :
             textView.setOnClickListener {
                 curMission?.let { mission ->
                     val intent = Intent(view.context, ItineraryShowActivity::class.java)
-                    val flightPathArrayList: ArrayList<LatLng> = ArrayList(mission.flightPath) //ArrayList implements Serializable, not List
 
-                    intent.putExtra(MISSION_PATH, flightPathArrayList)
-                    intent.putExtra(OWNER, mission.ownerUid)
-                    intent.putExtra(PRIVATE, mission.privateId)
-                    intent.putExtra(SHARED, mission.sharedId)
+                    intent.putExtra(FLIGHTHEIGHT_INTENT_PATH, mission.flightHeight)
+                    intent.putExtra(AREA_INTENT_PATH, ArrayList(mission.area))
+                    intent.putExtra(STRATEGY_INTENT_PATH, mission.strategy)
+                    intent.putExtra(OWNER_ID_INTENT_PATH, mission.ownerUid)
+                    intent.putExtra(PRIVATE_ID_INTENT_PATH, mission.privateId)
+                    intent.putExtra(SHARED_ID_INTENT_PATH, mission.sharedId)
 
                     view.context.startActivity(intent)
                 }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivity.kt
@@ -52,8 +52,7 @@ class SaveMappingMissionActivity : AppCompatActivity() {
         val bundle = intent.extras
         if (bundle != null) {
             flightHeight = bundle.getDouble(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH)
-            strategy = bundle.get(ItineraryCreateActivity.STRATEGY_INTENT_PATH) as MappingMissionService.Strategy
-            //strategy = MappingMissionService.Strategy.valueOf(bundle.getString(ItineraryCreateActivity.STRATEGY_INTENT_PATH)!!)
+            strategy = (bundle.get(ItineraryCreateActivity.STRATEGY_INTENT_PATH) as MappingMissionService.Strategy)!!
             area = bundle.getParcelableArrayList(ItineraryCreateActivity.AREA_INTENT_PATH)!!
         }
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivity.kt
@@ -51,8 +51,9 @@ class SaveMappingMissionActivity : AppCompatActivity() {
 
         val bundle = intent.extras
         if (bundle != null) {
-            flightHeight = bundle.getDouble(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH)!!
-            strategy = (bundle.get(ItineraryCreateActivity.STRATEGY_INTENT_PATH) as MappingMissionService.Strategy?)!!
+            flightHeight = bundle.getDouble(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH)
+            strategy = bundle.get(ItineraryCreateActivity.STRATEGY_INTENT_PATH) as MappingMissionService.Strategy
+            //strategy = MappingMissionService.Strategy.valueOf(bundle.getString(ItineraryCreateActivity.STRATEGY_INTENT_PATH)!!)
             area = bundle.getParcelableArrayList(ItineraryCreateActivity.AREA_INTENT_PATH)!!
         }
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivity.kt
@@ -15,11 +15,13 @@ import androidx.lifecycle.MediatorLiveData
 import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.model.mission.MappingMission
 import ch.epfl.sdp.drone3d.service.api.auth.AuthenticationService
+import ch.epfl.sdp.drone3d.service.api.mission.MappingMissionService
 import ch.epfl.sdp.drone3d.service.api.storage.dao.MappingMissionDao
 import ch.epfl.sdp.drone3d.ui.ToastHandler
 import com.mapbox.mapboxsdk.geometry.LatLng
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlin.properties.Delegates
 
 /**
  * This activity let the user name then store and/or share a mapping mission.
@@ -37,7 +39,10 @@ class SaveMappingMissionActivity : AppCompatActivity() {
     private lateinit var sharedCheckBox: CheckBox
     private lateinit var saveButton: Button
 
-    private lateinit var flightPath: List<LatLng>
+    private var flightHeight by Delegates.notNull<Double>()
+    private lateinit var strategy: MappingMissionService.Strategy
+    private lateinit var area: List<LatLng>
+
 
     private lateinit var nameEditText: EditText
 
@@ -46,7 +51,9 @@ class SaveMappingMissionActivity : AppCompatActivity() {
 
         val bundle = intent.extras
         if (bundle != null) {
-            flightPath = bundle.getParcelableArrayList("flightPath")!!
+            flightHeight = bundle.getDouble(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH)!!
+            strategy = (bundle.get(ItineraryCreateActivity.STRATEGY_INTENT_PATH) as MappingMissionService.Strategy?)!!
+            area = bundle.getParcelableArrayList(ItineraryCreateActivity.AREA_INTENT_PATH)!!
         }
 
         //Create a "back button" in the action bar up
@@ -124,7 +131,7 @@ class SaveMappingMissionActivity : AppCompatActivity() {
         saveButton.isEnabled = false;
 
         val name = if (nameEditText.text.isEmpty()) "Unnamed mission" else nameEditText.text
-        val newMappingMission = MappingMission(name.toString(), flightPath)
+        val newMappingMission = MappingMission(name.toString(), flightHeight, strategy, area)
 
         // The user should be logged to access this page
         val ownerId = authService.getCurrentSession()!!.user.uid

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/SaveMappingMissionActivity.kt
@@ -52,7 +52,7 @@ class SaveMappingMissionActivity : AppCompatActivity() {
         val bundle = intent.extras
         if (bundle != null) {
             flightHeight = bundle.getDouble(ItineraryCreateActivity.FLIGHTHEIGHT_INTENT_PATH)
-            strategy = (bundle.get(ItineraryCreateActivity.STRATEGY_INTENT_PATH) as MappingMissionService.Strategy)!!
+            strategy = (bundle.get(ItineraryCreateActivity.STRATEGY_INTENT_PATH) as MappingMissionService.Strategy)
             area = bundle.getParcelableArrayList(ItineraryCreateActivity.AREA_INTENT_PATH)!!
         }
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/weather/WeatherInfoActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/weather/WeatherInfoActivity.kt
@@ -56,8 +56,7 @@ class WeatherInfoActivity : AppCompatActivity() {
 
         nonExistentMission = findViewById(R.id.nonExistentMission)
 
-        @Suppress("UNCHECKED_CAST")
-        location = intent.getSerializableExtra(ItineraryShowActivity.FLIGHTPATH_INTENT_PATH) as ArrayList<LatLng>?
+        location = intent.getParcelableArrayListExtra(ItineraryShowActivity.FLIGHTPATH_INTENT_PATH)
 
         if (location == null || location!!.isEmpty()) {
             setupInvalidMission()

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/weather/WeatherInfoActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/weather/WeatherInfoActivity.kt
@@ -15,6 +15,7 @@ import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.model.weather.WeatherReport
 import ch.epfl.sdp.drone3d.service.api.weather.WeatherService
 import ch.epfl.sdp.drone3d.service.impl.weather.WeatherUtils
+import ch.epfl.sdp.drone3d.ui.mission.ItineraryShowActivity
 import ch.epfl.sdp.drone3d.ui.mission.MissionViewAdapter
 import com.mapbox.mapboxsdk.geometry.LatLng
 import dagger.hilt.android.AndroidEntryPoint
@@ -56,7 +57,7 @@ class WeatherInfoActivity : AppCompatActivity() {
         nonExistentMission = findViewById(R.id.nonExistentMission)
 
         @Suppress("UNCHECKED_CAST")
-        location = intent.getSerializableExtra(MissionViewAdapter.MISSION_PATH) as ArrayList<LatLng>?
+        location = intent.getSerializableExtra(ItineraryShowActivity.FLIGHTPATH_INTENT_PATH) as ArrayList<LatLng>?
 
         if (location == null || location!!.isEmpty()) {
             setupInvalidMission()

--- a/app/src/main/res/layout/activity_itinerary_show.xml
+++ b/app/src/main/res/layout/activity_itinerary_show.xml
@@ -48,6 +48,7 @@
         android:layout_margin="30sp"
         android:clickable="true"
         android:contentDescription="@string/content_descriptor_drone_icon"
+        android:enabled="true"
         android:onClick="launchMission"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="cancel_save_without_updating">Cancel</string>
     <string name="save_without_updating_confirmation">You have updated the mission settings since the last flight path preview. Do you want to save the mission without having seen the updated preview ?</string>
     <string name="drone_should_be_connected">"A drone or a simulation should be connected"</string>
+    <string name="altitude_text">"Altitude: %1$.0f m"</string>
 
     <!--Manage offline map activity-->
     <string name="tile_count">Tile count:</string>
@@ -76,8 +77,6 @@
     <string name="download_succeeded">The download of: %1$s has succeeded</string>
     <string name="download_progress">The download is at: %1$s completion</string>
     <string name="tile_limit_exceeded">Download paused, the tile limit has been exceeded</string>
-
-
 
     <!-- Mapping Mission Selection Activity -->
     <string name="create_mapping_mission_button_text">Create new mapping mission</string>
@@ -97,8 +96,6 @@
     <string name="launch_no_drone">A drone should be connected to launch the mission.</string>
     <string name="launch_no_drone_pos">Failed to get the drone location.</string>
     <string name="drone_too_far_from_start">The drone is too far from the starting point of the mission.</string>
-
-
 
     <!-- Mission In Progress Activity -->
     <string name="mission_null">Cannot launch a null mission</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,7 +64,7 @@
     <string name="map_not_ready">MAP NOT READY</string>
     <string name="confirm_save_without_updating">Save anyway</string>
     <string name="cancel_save_without_updating">Cancel</string>
-    <string name="save_without_updating_confirmation">The settings of the mission have changed since the last build. Do you want to save without updating the mission ?</string>
+    <string name="save_without_updating_confirmation">You have updated the mission settings since the last flight path preview. Do you want to save the mission without having seen the updated preview ?</string>
     <string name="drone_should_be_connected">"A drone or a simulation should be connected"</string>
 
     <!--Manage offline map activity-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,11 @@
     <string name="confirm_launch">Launch at my own risk</string>
     <string name="cancel_launch">Cancel</string>
     <string name="content_descriptor_drone_icon">drone_icon</string>
+    <string name="launch_no_drone">A drone should be connected to launch the mission.</string>
+    <string name="launch_no_drone_pos">Failed to get the drone location.</string>
+    <string name="drone_too_far_from_start">The drone is too far from the starting point of the mission.</string>
+
+
 
     <!-- Mission In Progress Activity -->
     <string name="mission_null">Cannot launch a null mission</string>


### PR DESCRIPTION
Since a flightpath is related to a drone it dosn't make sens to share a flightpath to other.
This PR modifiy mappingMission so that it stores the settings (flightheight, area and startegy) instead.
So it modifes ItineraryCreateActivity and SaveMappingMissionActivity to create a mapping mission.
MissionViewAdapter to transfer data to ItineraryShowActivity which it-self has been modified to generate the flightpath based on the recieved mappingMission.

It improves the feedback in ItineraryShowActivity. The user can always press the button launching the mission but a toast is dsiplayed when the condition aren't corrects.

And finally all tests related to thoses activites have been modified accordingly. 