### PR TITLE
Create square to display regions in the offline map activity

### DIFF
--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/map/offline/ManageOfflineMapActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/map/offline/ManageOfflineMapActivity.kt
@@ -114,7 +114,7 @@ class ManageOfflineMapActivity : BaseMapActivity(), OnMapReadyCallback {
     private fun bindOfflineRegionsToRecycler() {
         val savedRegionsRecycler = findViewById<RecyclerView>(R.id.saved_regions)
         val offlineRegions = offlineMapSaver.getOfflineRegions()
-        val adapter = OfflineRegionViewAdapter(offlineMapSaver, lineManager)
+        val adapter = OfflineRegionViewAdapter(offlineMapSaver, lineManager, mapboxMap)
         savedRegionsRecycler.adapter = adapter
 
         offlineRegions.observe(this, androidx.lifecycle.Observer {
@@ -211,7 +211,6 @@ class ManageOfflineMapActivity : BaseMapActivity(), OnMapReadyCallback {
         lineManager.create(LineOptions().withLatLngs(
             listOf(bounds.northEast, bounds.northWest, bounds.southWest, bounds.southEast, bounds.northEast)
         ))
-
     }
 
 }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/map/offline/ManageOfflineMapActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/map/offline/ManageOfflineMapActivity.kt
@@ -26,6 +26,8 @@ import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.offline.OfflineRegion
 import com.mapbox.mapboxsdk.offline.OfflineRegionError
 import com.mapbox.mapboxsdk.offline.OfflineRegionStatus
+import com.mapbox.mapboxsdk.plugins.annotation.LineManager
+import com.mapbox.mapboxsdk.plugins.annotation.LineOptions
 import timber.log.Timber
 import java.lang.System.currentTimeMillis
 import kotlin.math.min
@@ -42,6 +44,7 @@ class ManageOfflineMapActivity : BaseMapActivity(), OnMapReadyCallback {
         private const val BACKGROUND_COLOR_MULTIPLIER = -0x1000000
     }
 
+    private lateinit var lineManager: LineManager
     private lateinit var offlineMapSaver: OfflineMapSaver
     private lateinit var mapboxMap: MapboxMap
     private lateinit var downloadButton: FloatingActionButton
@@ -67,6 +70,7 @@ class ManageOfflineMapActivity : BaseMapActivity(), OnMapReadyCallback {
 
         mapboxMap.setStyle(Style.MAPBOX_STREETS) { style ->
 
+            lineManager = LineManager(mapView, mapboxMap, style)
             offlineMapSaver = OfflineMapSaverImpl(this@ManageOfflineMapActivity, style.uri)
             bindOfflineRegionsToRecycler()
             downloadButton.isEnabled = true
@@ -110,7 +114,7 @@ class ManageOfflineMapActivity : BaseMapActivity(), OnMapReadyCallback {
     private fun bindOfflineRegionsToRecycler() {
         val savedRegionsRecycler = findViewById<RecyclerView>(R.id.saved_regions)
         val offlineRegions = offlineMapSaver.getOfflineRegions()
-        val adapter = OfflineRegionViewAdapter(offlineMapSaver)
+        val adapter = OfflineRegionViewAdapter(offlineMapSaver, lineManager)
         savedRegionsRecycler.adapter = adapter
 
         offlineRegions.observe(this, androidx.lifecycle.Observer {
@@ -203,7 +207,11 @@ class ManageOfflineMapActivity : BaseMapActivity(), OnMapReadyCallback {
      * Display the [offlineRegion] on the map by putting a square surrounding the region on the map
      */
     private fun display(offlineRegion: OfflineRegion){
-        //TODO("Implement")
+        val bounds = OfflineMapSaverImpl.getMetadata(offlineRegion).bounds
+        lineManager.create(LineOptions().withLatLngs(
+            listOf(bounds.northEast, bounds.northWest, bounds.southWest, bounds.southEast, bounds.northEast)
+        ))
+
     }
 
 }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/map/offline/OfflineRegionViewAdapter.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/map/offline/OfflineRegionViewAdapter.kt
@@ -13,13 +13,16 @@ import ch.epfl.sdp.drone3d.map.offline.OfflineMapSaverImpl.Companion.getMetadata
 import ch.epfl.sdp.drone3d.ui.ToastHandler
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.mapbox.mapboxsdk.offline.OfflineRegion
+import com.mapbox.mapboxsdk.plugins.annotation.Line
+import com.mapbox.mapboxsdk.plugins.annotation.LineManager
+import com.mapbox.mapboxsdk.plugins.annotation.LineOptions
 import timber.log.Timber
 
 /**
  * ViewAdapter for the RecyclerView holding OfflineRegions. Use an [offlineMapSaver] to delete
  * the missions when we click on the delete button.
  */
-class OfflineRegionViewAdapter(private val offlineMapSaver: OfflineMapSaver) :
+class OfflineRegionViewAdapter(private val offlineMapSaver: OfflineMapSaver, private val lineManager: LineManager) :
     ListAdapter<OfflineRegion, OfflineRegionViewAdapter.OfflineRegionViewHolder>(RegionDiff) {
 
     /**
@@ -36,15 +39,17 @@ class OfflineRegionViewAdapter(private val offlineMapSaver: OfflineMapSaver) :
          * Bind holder with the [OfflineRegion] by setting the name in the textView and the
          * onClickListener of the button to delete it using the [offlineMapSaver].
          */
-        fun bind(offRegion: OfflineRegion, offlineMapSaver: OfflineMapSaver) {
+        fun bind(offRegion: OfflineRegion, offlineMapSaver: OfflineMapSaver, lineManager: LineManager) {
             offlineRegion = offRegion
-            textView.text = getMetadata(offRegion).name
+            val metadata = getMetadata(offRegion)
+            textView.text = metadata.name
 
             deleteButton.setOnClickListener {
                 offlineMapSaver.deleteRegion(
                     offRegion.id,
                     object : OfflineRegion.OfflineRegionDeleteCallback {
                         override fun onDelete() {
+                            lineManager.deleteAll()
                             ToastHandler.showToast(it.context, R.string.delete_successful)
                         }
 
@@ -66,7 +71,7 @@ class OfflineRegionViewAdapter(private val offlineMapSaver: OfflineMapSaver) :
     }
 
     override fun onBindViewHolder(holder: OfflineRegionViewHolder, position: Int) {
-        holder.bind(getItem(position), offlineMapSaver)
+        holder.bind(getItem(position), offlineMapSaver, lineManager)
     }
 
     override fun getItemCount(): Int {


### PR DESCRIPTION
Add a square on the map in ManageOfflineMapActivity around the downloaded offline regions and zoom on them when we click on the names of the regions.