### PR TITLE
Update mavsdk and mavsdk-server to 0.9.x

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,8 +76,8 @@ dependencies {
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
 
     // Import mavsdk to control the drone
-    implementation 'io.mavsdk:mavsdk:0.8.0'
-    implementation 'io.mavsdk:mavsdk-server:0.8.1'
+    implementation 'io.mavsdk:mavsdk:0.9.0'
+    implementation 'io.mavsdk:mavsdk-server:0.9.1'
 
     // Video stream
     implementation fileTree(dir: 'libs', include: '*.aar')


### PR DESCRIPTION
There is a bug before mavsdk 0.9.x where the gimbal orientation is ignored during the mission. Should be fixed with 0.9.x (mavsdk:0.9.0 and mavsdk-server:0.9.1)