### PR TITLE
Close keyboard when drone connect

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/ItineraryCreateActivityTest.kt
@@ -129,7 +129,7 @@ class ItineraryCreateActivityTest {
         onView(withText(R.string.go_to_login)).check(matches(isDisplayed()))
         onView(withText(R.string.go_to_login)).perform(click())
 
-        sleep(100)
+        sleep(400)
 
         Intents.intended(
             hasComponent(hasClassName(LoginActivity::class.java.name))

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/Utils.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/Utils.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2021  Drone3D-Team
+ * The license can be found in LICENSE at root of the repository
+ */
+
 package ch.epfl.sdp.drone3d.ui
 
 import android.content.Context
@@ -16,7 +21,7 @@ object Utils {
      * button is pressed on the keyboard
      * Requires the editText to have 'android:imeOptions="actionDone"' in its layout
      */
-    fun setupPortTextListener(editText: EditText, button: Button) {
+    fun pressButtonWhenTextIsDone(editText: EditText, button: Button) {
         editText.setOnEditorActionListener(TextView.OnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_DONE) {
                 button.performClick()

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/Utils.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/Utils.kt
@@ -1,0 +1,37 @@
+package ch.epfl.sdp.drone3d.ui
+
+import android.content.Context
+import android.content.Context.INPUT_METHOD_SERVICE
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+
+object Utils {
+
+    /**
+     * Creates a listener on [editText] that presses [button] when the done
+     * button is pressed on the keyboard
+     * Requires the editText to have 'android:imeOptions="actionDone"' in its layout
+     */
+    fun setupPortTextListener(editText: EditText, button: Button) {
+        editText.setOnEditorActionListener(TextView.OnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                button.performClick()
+                return@OnEditorActionListener true
+            }
+            false
+        })
+    }
+
+    /**
+     * Closes the keyboard of the activity whose context and view is passed
+     */
+    fun closeKeyboard(view: View, context: Context) {
+        val inputMethodManager: InputMethodManager =
+            context.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(view.applicationWindowToken, 0)
+    }
+}

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/Utils.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/Utils.kt
@@ -19,7 +19,7 @@ object Utils {
     /**
      * Creates a listener on [editText] that presses [button] when the done
      * button is pressed on the keyboard
-     * Requires the editText to have 'android:imeOptions="actionDone"' in its layout
+     * Requires [editText] to have 'android:imeOptions="actionDone"' in its layout
      */
     fun pressButtonWhenTextIsDone(editText: EditText, button: Button) {
         editText.setOnEditorActionListener(TextView.OnEditorActionListener { _, actionId, _ ->
@@ -32,7 +32,7 @@ object Utils {
     }
 
     /**
-     * Closes the keyboard of the activity whose context and view is passed
+     * Closes the keyboard of the activity whose [context] and [view] is passed
      */
     fun closeKeyboard(view: View, context: Context) {
         val inputMethodManager: InputMethodManager =

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/auth/LoginActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/auth/LoginActivity.kt
@@ -8,11 +8,13 @@ package ch.epfl.sdp.drone3d.ui.auth
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
 import android.widget.EditText
 import android.widget.Toast
 import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.ui.MainActivity
 import ch.epfl.sdp.drone3d.ui.ToastHandler
+import ch.epfl.sdp.drone3d.ui.Utils
 
 /**
  * The activity that allows the user to log in
@@ -35,6 +37,9 @@ class LoginActivity : AuthActivity() {
         passwordEditText.setAutofillHints(View.AUTOFILL_HINT_PASSWORD)
 
         infoText.text = getString(R.string.login_info_default)
+
+        val loginButton: Button = findViewById(R.id.loginButton)
+        Utils.pressButtonWhenTextIsDone(passwordEditText, loginButton)
     }
 
     override fun success() {
@@ -46,7 +51,9 @@ class LoginActivity : AuthActivity() {
     /**
      * Login an user by taking the contents of [emailEditText] and of [passwordEditText]
      */
-    fun login(@Suppress("UNUSED_PARAMETER") view: View) {
+    fun login(view: View) {
+
+        Utils.closeKeyboard(view, this)
         val emailText = emailEditText.text.toString()
         val passwordText = passwordEditText.text.toString()
         if (emailText == "" || passwordText == "") {
@@ -55,7 +62,8 @@ class LoginActivity : AuthActivity() {
         } else {
             startProcess(
                 authService.login(emailEditText.text.toString(), passwordEditText.text.toString()),
-                R.string.login_fail)
+                R.string.login_fail
+            )
         }
     }
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/auth/RegisterActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/auth/RegisterActivity.kt
@@ -8,10 +8,12 @@ package ch.epfl.sdp.drone3d.ui.auth
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
 import android.widget.EditText
 import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.ui.MainActivity
 import ch.epfl.sdp.drone3d.ui.ToastHandler
+import ch.epfl.sdp.drone3d.ui.Utils
 
 /**
  * The activity that allows the user to register
@@ -37,6 +39,9 @@ class RegisterActivity : AuthActivity() {
         passwordEditText.setAutofillHints(View.AUTOFILL_HINT_PASSWORD)
 
         infoText.text = getString(R.string.register_info_default)
+
+        val registerButton: Button = findViewById(R.id.registerButton)
+        Utils.pressButtonWhenTextIsDone(passwordEditText, registerButton)
     }
 
     override fun success() {
@@ -49,7 +54,8 @@ class RegisterActivity : AuthActivity() {
     /**
      * Register an user by taking the contents of [emailEditText], of [passwordEditText] and of [pseudoEditText]
      */
-    fun register(@Suppress("UNUSED_PARAMETER") view: View) {
+    fun register(view: View) {
+        Utils.closeKeyboard(view, this)
         val emailText = emailEditText.text.toString()
         val passwordText = passwordEditText.text.toString()
         if (emailText == "" || passwordText == "") {
@@ -59,8 +65,10 @@ class RegisterActivity : AuthActivity() {
             startProcess(
                 authService.register(
                     emailEditText.text.toString(),
-                    passwordEditText.text.toString()),
-                R.string.register_fail)
+                    passwordEditText.text.toString()
+                ),
+                R.string.register_fail
+            )
         }
     }
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/drone/DroneConnectActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/drone/DroneConnectActivity.kt
@@ -9,17 +9,15 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.view.View
-import android.view.inputmethod.EditorInfo
-import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ProgressBar
 import android.widget.TextView
-import android.widget.TextView.OnEditorActionListener
 import androidx.appcompat.app.AppCompatActivity
 import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.service.api.drone.DroneService
 import ch.epfl.sdp.drone3d.ui.ToastHandler
+import ch.epfl.sdp.drone3d.ui.Utils
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
 import java.lang.Runnable
@@ -67,7 +65,7 @@ class DroneConnectActivity : AppCompatActivity() {
         loadingProgressBar = findViewById(R.id.progress_bar_drone)
         waitingText = findViewById(R.id.waiting_connection)
 
-        setupPortTextListener()
+        Utils.setupPortTextListener(portText, simulationConnectButton)
 
         showConnectionOptions()
     }
@@ -77,7 +75,7 @@ class DroneConnectActivity : AppCompatActivity() {
      */
     fun connectSimulatedDrone(view: View) {
 
-        closeKeyboard(view)
+        Utils.closeKeyboard(view, this)
 
         val ip = findViewById<EditText>(R.id.text_IP_address).text.toString()
 
@@ -121,7 +119,7 @@ class DroneConnectActivity : AppCompatActivity() {
      */
     fun connectDrone(view: View) {
 
-        closeKeyboard(view)
+        Utils.closeKeyboard(view, this)
 
         showWaiting()
         droneService.setDrone()
@@ -191,29 +189,5 @@ class DroneConnectActivity : AppCompatActivity() {
     private fun verifyIp(ip: String): Boolean {
         val matcher: Matcher = pattern.matcher(ip)
         return matcher.matches()
-    }
-
-
-    /**
-     * Closes the keyboard
-     */
-    private fun closeKeyboard(view: View) {
-        val inputMethodManager: InputMethodManager =
-            getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
-        inputMethodManager.hideSoftInputFromWindow(view.applicationWindowToken, 0)
-    }
-
-    /**
-     * Creates a listener on the connection port text view that launches the
-     * connection when enter is pressed
-     */
-    private fun setupPortTextListener() {
-        portText.setOnEditorActionListener(OnEditorActionListener { _, actionId, _ ->
-            if (actionId == EditorInfo.IME_ACTION_DONE) {
-                simulationConnectButton.performClick()
-                return@OnEditorActionListener true
-            }
-            false
-        })
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/drone/DroneConnectActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/drone/DroneConnectActivity.kt
@@ -65,7 +65,7 @@ class DroneConnectActivity : AppCompatActivity() {
         loadingProgressBar = findViewById(R.id.progress_bar_drone)
         waitingText = findViewById(R.id.waiting_connection)
 
-        Utils.setupPortTextListener(portText, simulationConnectButton)
+        Utils.pressButtonWhenTextIsDone(portText, simulationConnectButton)
 
         showConnectionOptions()
     }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/drone/DroneConnectActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/drone/DroneConnectActivity.kt
@@ -70,7 +70,7 @@ class DroneConnectActivity : AppCompatActivity() {
     /**
      * Connect a simulation to the application using an ip address and a port
      */
-    fun connectSimulatedDrone(@Suppress("UNUSED_PARAMETER") view: View) {
+    fun connectSimulatedDrone(view: View) {
 
         closeKeyboard(view)
 
@@ -114,7 +114,7 @@ class DroneConnectActivity : AppCompatActivity() {
     /**
      * Connect a drone to the application
      */
-    fun connectDrone(@Suppress("UNUSED_PARAMETER") view: View) {
+    fun connectDrone(view: View) {
 
         closeKeyboard(view)
 

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/drone/DroneConnectActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/drone/DroneConnectActivity.kt
@@ -9,11 +9,13 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.widget.TextView.OnEditorActionListener
 import androidx.appcompat.app.AppCompatActivity
 import ch.epfl.sdp.drone3d.R
 import ch.epfl.sdp.drone3d.service.api.drone.DroneService
@@ -24,6 +26,7 @@ import java.lang.Runnable
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import javax.inject.Inject
+
 
 @AndroidEntryPoint
 class DroneConnectActivity : AppCompatActivity() {
@@ -63,6 +66,8 @@ class DroneConnectActivity : AppCompatActivity() {
 
         loadingProgressBar = findViewById(R.id.progress_bar_drone)
         waitingText = findViewById(R.id.waiting_connection)
+
+        setupPortTextListener()
 
         showConnectionOptions()
     }
@@ -196,5 +201,19 @@ class DroneConnectActivity : AppCompatActivity() {
         val inputMethodManager: InputMethodManager =
             getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
         inputMethodManager.hideSoftInputFromWindow(view.applicationWindowToken, 0)
+    }
+
+    /**
+     * Creates a listener on the connection port text view that launches the
+     * connection when enter is pressed
+     */
+    private fun setupPortTextListener() {
+        portText.setOnEditorActionListener(OnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                simulationConnectButton.performClick()
+                return@OnEditorActionListener true
+            }
+            false
+        })
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/drone/DroneConnectActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/drone/DroneConnectActivity.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ProgressBar
@@ -71,6 +72,8 @@ class DroneConnectActivity : AppCompatActivity() {
      */
     fun connectSimulatedDrone(@Suppress("UNUSED_PARAMETER") view: View) {
 
+        closeKeyboard(view)
+
         val ip = findViewById<EditText>(R.id.text_IP_address).text.toString()
 
         if (verifyIp(ip)) {
@@ -95,7 +98,10 @@ class DroneConnectActivity : AppCompatActivity() {
                     } else {
                         droneService.disconnect()
                         showConnectionOptions()
-                        ToastHandler.showToastAsync(applicationContext, R.string.ip_connection_timeout)
+                        ToastHandler.showToastAsync(
+                            applicationContext,
+                            R.string.ip_connection_timeout
+                        )
                     }
                 }
                 mainHandler.post(myRunnable)
@@ -109,6 +115,8 @@ class DroneConnectActivity : AppCompatActivity() {
      * Connect a drone to the application
      */
     fun connectDrone(@Suppress("UNUSED_PARAMETER") view: View) {
+
+        closeKeyboard(view)
 
         showWaiting()
         droneService.setDrone()
@@ -178,5 +186,15 @@ class DroneConnectActivity : AppCompatActivity() {
     private fun verifyIp(ip: String): Boolean {
         val matcher: Matcher = pattern.matcher(ip)
         return matcher.matches()
+    }
+
+
+    /**
+     * Closes the keyboard
+     */
+    private fun closeKeyboard(view: View) {
+        val inputMethodManager: InputMethodManager =
+            getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(view.applicationWindowToken, 0)
     }
 }

--- a/app/src/main/res/layout/activity_drone_connect.xml
+++ b/app/src/main/res/layout/activity_drone_connect.xml
@@ -49,6 +49,7 @@
         android:ems="10"
         android:hint="@string/drone_connect_port_default"
         android:inputType="number"
+        android:imeOptions="actionDone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.477"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -66,6 +66,7 @@
         android:importantForAutofill="no"
         android:textColor="@color/black"
         android:textSize="18sp"
+        android:imeOptions="actionDone"
         app:layout_constraintBottom_toBottomOf="@id/passwordText"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -93,6 +93,7 @@
         android:importantForAutofill="no"
         android:textColor="@color/black"
         android:textSize="18sp"
+        android:imeOptions="actionDone"
         app:layout_constraintBottom_toBottomOf="@id/passwordText"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"


### PR DESCRIPTION
This PR ensures that the keyboard closes when we connect a drone or a simulation.
As their is no direct way to [know if a keyboard is opened or close on Android](https://stackoverflow.com/questions/4745988/how-do-i-detect-if-software-keyboard-is-visible-on-android-device-or-not), I could not add any tests. 