### PR TITLE
Fix mission start text and return button for the pictures activity

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/MissionStartActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/drone3d/ui/mission/MissionStartActivityTest.kt
@@ -137,6 +137,9 @@ class MissionStartActivityTest {
         blockingSetValue(droneStatus, STARTING_MISSION)
         onView(withId(R.id.mission_start_text)).check(matches(withText(R.string.mission_state_starting)))
 
+        blockingSetValue(droneStatus, EXECUTING_MISSION)
+        onView(withId(R.id.mission_start_text)).check(matches(withText(R.string.mission_state_executing)))
+
         missionExecutionEnd.onComplete()
         intended(
             hasComponent(ComponentNameMatchers.hasClassName(MissionInProgressActivity::class.java.name))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,8 +26,12 @@
         <activity
             android:name=".ui.weather.WeatherInfoActivity"
             android:parentActivityName=".ui.mission.ItineraryShowActivity" />
-        <activity android:name=".ui.map.MissionInProgressActivity" />
-        <activity android:name=".ui.mission.MissionPicturesActivity" />
+        <activity
+            android:name=".ui.map.MissionInProgressActivity"
+            android:parentActivityName=".ui.mission.ItineraryShowActivity" />
+        <activity
+            android:name=".ui.mission.MissionPicturesActivity"
+            android:parentActivityName=".ui.mission.ItineraryShowActivity" />
         <activity
             android:name=".ui.mission.ItineraryShowActivity"
             android:launchMode="singleTop"

--- a/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MissionStartActivity.kt
+++ b/app/src/main/java/ch/epfl/sdp/drone3d/ui/mission/MissionStartActivity.kt
@@ -36,7 +36,8 @@ class MissionStartActivity : AppCompatActivity() {
             IDLE,
             SENDING_ORDER,
             ARMING,
-            STARTING_MISSION
+            STARTING_MISSION,
+            EXECUTING_MISSION
         )
     }
 
@@ -87,6 +88,7 @@ class MissionStartActivity : AppCompatActivity() {
                 ARMING -> R.string.mission_state_arming
                 SENDING_ORDER -> R.string.mission_state_sending
                 STARTING_MISSION -> R.string.mission_state_starting
+                EXECUTING_MISSION -> R.string.mission_state_executing
                 else -> R.string.mission_state_unknown
             }
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,6 +146,7 @@
     <string name="mission_state_arming">Arming the drone</string>
     <string name="mission_state_sending">Sending the mission to the drone</string>
     <string name="mission_state_starting">The mission is starting</string>
+    <string name="mission_state_executing">The mission is being executed</string>
     <string name="mission_state_unknown">The drone is in an unknown state. Are you the only one controlling it ?</string>
 
     <!-- Weather Info Activity -->


### PR DESCRIPTION
Fix the status text in mission start activity where it says that the drone is in an unknown state while in reality it is on executing missions state. Also makes the return button in mission pictures activity go back to itinerary show activity with the previous mission.

Closes #331